### PR TITLE
Fix format error immediately after startup

### DIFF
--- a/RunCat/Program.cs
+++ b/RunCat/Program.cs
@@ -133,7 +133,7 @@ namespace RunCat
         private void ObserveCPUTick(object sender, EventArgs e)
         {
             float s = cpuUsage.NextValue();
-            notifyIcon.Text = String.Format("{0:#.#}%", s);
+            notifyIcon.Text = $"{s:f1}%";
             s = 200.0f / (float)Math.Max(1.0f, Math.Min(20.0f, s / 5.0f));
             animateTimer.Stop();
             animateTimer.Interval = (int)s;

--- a/RunCat/Program.cs
+++ b/RunCat/Program.cs
@@ -50,6 +50,7 @@ namespace RunCat
             SystemEvents.UserPreferenceChanged += new UserPreferenceChangedEventHandler(UserPreferenceChanged);
 
             cpuUsage = new PerformanceCounter("Processor", "% Processor Time", "_Total");
+            _ = cpuUsage.NextValue(); // discards first return value
 
             notifyIcon = new NotifyIcon()
             {


### PR DESCRIPTION
closes #1

- uses the string literal on `notifyIcon.Text`
- discards the first return value of `cpuUsage.NextValue()`