### PR TITLE
GetAppsUseTheme refactoring

### DIFF
--- a/RunCat/Program.cs
+++ b/RunCat/Program.cs
@@ -75,10 +75,11 @@ namespace RunCat
             string keyName = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
             try
             {
-                RegistryKey rKey = Registry.CurrentUser.OpenSubKey(keyName);
-                int theme = (int)rKey.GetValue("SystemUsesLightTheme");
-                rKey.Close();
-                return theme == 0 ? "dark" : "light";
+                using (RegistryKey rKey = Registry.CurrentUser.OpenSubKey(keyName))
+                {
+                    int theme = (int)rKey.GetValue("SystemUsesLightTheme");
+                    return theme == 0 ? "dark" : "light";
+                }
             }
             catch (NullReferenceException)
             {

--- a/RunCat/Program.cs
+++ b/RunCat/Program.cs
@@ -73,18 +73,16 @@ namespace RunCat
         private string GetAppsUseTheme()
         {
             string keyName = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
-            try
+            using (RegistryKey rKey = Registry.CurrentUser.OpenSubKey(keyName))
             {
-                using (RegistryKey rKey = Registry.CurrentUser.OpenSubKey(keyName))
+                object value;
+                if (rKey == null || (value = rKey.GetValue("SystemUsesLightTheme")) == null)
                 {
-                    int theme = (int)rKey.GetValue("SystemUsesLightTheme");
-                    return theme == 0 ? "dark" : "light";
+                    Console.WriteLine("Oh No! Couldn't get theme light/dark");
+                    return "light";
                 }
-            }
-            catch (NullReferenceException)
-            {
-                Console.WriteLine("Oh No! Couldn't get theme light/dark");
-                return "light";
+                int theme = (int)value;
+                return theme == 0 ? "dark" : "light";
             }
         }
 


### PR DESCRIPTION
Fixed about #8 

It was not disposed when using the RegistryKey object.
And also, the condition judgment using Exception was not preferable.
Therefore, I have been made  the following modifications.
* Always dispose after using RegistryKey
* Removed condition judgment using NullReferenceException

Could you check this pull request? If it found no issues, could you please merge to master?