### PR TITLE
modified startup for .NET Core

### DIFF
--- a/RunCat/Program.cs
+++ b/RunCat/Program.cs
@@ -226,7 +226,7 @@ namespace RunCat
             {
                 if (startupMenu.Checked)
                 {
-                    rKey.SetValue(Application.ProductName, Application.ExecutablePath);
+                    rKey.SetValue(Application.ProductName, '"' + Process.GetCurrentProcess().MainModule.FileName + '"');
                 }
                 else
                 {


### PR DESCRIPTION
modified #15 (Runcat 1.7 does not work properly)

「Startup」で登録されるパスが dll になっていました。
これは .NET Framework から .NET Core に変更したことにより、Application.ExecutablePath が返すパスが dll になったためです。
release ビルドと publish の両方で動作を確認致しました。
宜しくお願い致します。