### PR TITLE
Fix to save app preferences

### DIFF
--- a/RunCat/Program.cs
+++ b/RunCat/Program.cs
@@ -133,6 +133,8 @@ namespace RunCat
             UserSettings.Default.Runner = runner;
             UserSettings.Default.Theme = manualTheme;
             UserSettings.Default.Save();
+
+            UserSettings.Default.Reload();
         }
 
         private bool IsStartupEnabled()


### PR DESCRIPTION
Fixed so preferences are saved and retrieved after reboot.

Previously, even changing the theme, for example, when starting the program, the default settings were used.

Issue #60.