### PR TITLE
fix run taskmgr.exe

### DIFF
--- a/RunCat/Program.cs
+++ b/RunCat/Program.cs
@@ -299,7 +299,14 @@ namespace RunCat
         
         private void HandleDoubleClick(object Sender, EventArgs e)
         {
-            System.Diagnostics.Process.Start("taskmgr.exe");
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "powershell",
+                UseShellExecute = false,
+                Arguments = " -c Start-Process taskmgr.exe",
+                CreateNoWindow = true,
+            };
+            Process.Start(startInfo);
         }
 
     }


### PR DESCRIPTION
Cannot run'taskmgr.exe' by double click tray icon on windows11.
The exception message shows that elevation is required ( actually, elevation is not required. It seems that there is bug in dotnet core, beacuse running 'taskmgr.exe' without elevation is ok when using dotnet framework). But running other process like 'powershell' is ok.
So the solution is starting a powershell process which runs a powershell command: Start-Process taskmgr.exe.