### PR TITLE
fix: include native libraries when publishing executable

### DIFF
--- a/RunCat/Properties/PublishProfiles/PublishWithDotNetProdile.pubxml
+++ b/RunCat/Properties/PublishProfiles/PublishWithDotNetProdile.pubxml
@@ -12,6 +12,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>
+    <IncludeNativeLibrariesForSelfExtract>True</IncludeNativeLibrariesForSelfExtract>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>


### PR DESCRIPTION
Fix: https://github.com/Kyome22/RunCat_for_windows/issues/96 https://github.com/Kyome22/RunCat_for_windows/issues/73 https://github.com/Kyome22/RunCat_for_windows/issues/44

set `IncludeNativeLibrariesForSelfExtract` to really publish a singe file without DLLs:
![image](https://user-images.githubusercontent.com/40566803/176115913-0027c886-86db-4880-a7a3-def5aff89082.png)

ref: https://github.com/dotnet/designs/blob/main/accepted/2020/single-file/design.md#user-experience
To publish single file executable without DLLs, we have to set `IncludeNativeLibrariesForSelfExtract` to true in ~~`RunCat.csproj`~~ `PublishWithDotNetProdile.pubxml`, otherwise we'll publish executable along with several DLLs:
![image](https://user-images.githubusercontent.com/40566803/176121579-c6b5b39f-5150-4acb-981b-40f526e67e41.png)
This is why some users (me included) can't run v1.10 and v1.11: **lack of some DLLs like `clrcompression.dll`**

Detailed explanation can be found at this issue: https://github.com/Kyome22/RunCat_for_windows/issues/96 