### PR TITLE
feat: trim executable

### DIFF
--- a/RunCat/Properties/PublishProfiles/PublishWithDotNetProdile.pubxml
+++ b/RunCat/Properties/PublishProfiles/PublishWithDotNetProdile.pubxml
@@ -13,6 +13,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <SelfContained>true</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>
     <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishTrimmed>False</PublishTrimmed>
+    <PublishTrimmed>True</PublishTrimmed>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Now the executable is too large (over 100MB), I trim the executable size by setting `PublishTrimmed` in ~~`RunCat.csproj`~~ `PublishWithDotNetProdile.pubxml`.
ref: https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained

size before is 147,800KB:
![image](https://user-images.githubusercontent.com/40566803/176126609-41704166-9911-43f0-8e24-8336859d8c0c.png)


size after is 84,974KB:
![image](https://user-images.githubusercontent.com/40566803/176126842-01a200d3-02c7-4128-bfb4-0b23783250c2.png)
