### PR TITLE
Increase CPU usage value precision and .NET 6 support

### DIFF
--- a/RunCat/Program.cs
+++ b/RunCat/Program.cs
@@ -76,7 +76,7 @@ namespace RunCat
 
             SystemEvents.UserPreferenceChanged += new UserPreferenceChangedEventHandler(UserPreferenceChanged);
 
-            cpuUsage = new PerformanceCounter("Processor", "% Processor Time", "_Total");
+            cpuUsage = new PerformanceCounter("Processor Information", "% Processor Utility", "_Total");
             _ = cpuUsage.NextValue(); // discards first return value
 
             runnerMenu = new ToolStripMenuItem("Runner", null, new ToolStripMenuItem[]

--- a/RunCat/RunCat.csproj
+++ b/RunCat/RunCat.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>appIcon.ico</ApplicationIcon>
     <NoWin32Manifest>true</NoWin32Manifest>


### PR DESCRIPTION
Applied new PerformanceCounter parameter that matches the CPU usage value of the Windows Task Manager.
And since .NET 5.0 is not officially supported now, I've updated it into .NET 6.0