### PR TITLE
Add alternative installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 
 **Access to the "Releases" page and download the RunCat.exe.**
 
-- Or install via [Scoop](https://github.com/ScoopInstaller/Scoop):
-`scoop install runcat`
+- Or install via [Scoop](https://github.com/ScoopInstaller/Scoop) (x64 version):
+`scoop install runcat` 
 
 # Contributors
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 
 **Access to the "Releases" page and download the RunCat.exe.**
 
+- Or install via [Scoop](https://github.com/ScoopInstaller/Scoop):
+`scoop install runcat`
 # Contributors
 
 <a href="https://github.com/Kyome22/RunCat_for_windows/graphs/contributors">

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 
 - Or install via [Scoop](https://github.com/ScoopInstaller/Scoop):
 `scoop install runcat`
+
 # Contributors
 
 <a href="https://github.com/Kyome22/RunCat_for_windows/graphs/contributors">


### PR DESCRIPTION
Scoop is a command-line installer for Windows, mainly for portable applications.