### PR TITLE
Add app version to menu

### DIFF
--- a/RunCat/Program.cs
+++ b/RunCat/Program.cs
@@ -148,6 +148,11 @@ namespace RunCat
                 themeMenu,
                 startupMenu,
                 runnerSpeedLimit,
+                new ToolStripSeparator(),
+                new ToolStripMenuItem($"{Application.ProductName} v{Application.ProductVersion}")
+                {
+                    Enabled = false
+                },
                 new ToolStripMenuItem("Exit", null, Exit)
             });
 


### PR DESCRIPTION
![Screenshot after applying this change](https://user-images.githubusercontent.com/82272900/178520154-c1b1c716-c167-4456-b6db-8f25020b3a1e.png)

Just a small addition: Application version in RunCat's menu.  
This will help users identify what version of RunCat is running easily.