### PR TITLE
Add scoop extra README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 **Access to the "Releases" page and download the RunCat.exe.**
 
 - Or install via [Scoop](https://github.com/ScoopInstaller/Scoop) (x64 version):
-`scoop install runcat` 
+`scoop bucket add extras`, `scoop install runcat` 
 
 # Contributors
 


### PR DESCRIPTION
I needed an `extra` bucket to install with scoop.
I referred to `LxRunOffline` for how to write `README`.
- [DDoSolitary/LxRunOffline: A full-featured utility for managing Windows Subsystem for Linux (WSL)](https://github.com/DDoSolitary/LxRunOffline)