### PR TITLE
Add CPU Temperature

### DIFF
--- a/RunCat365/RunCat365.csproj
+++ b/RunCat365/RunCat365.csproj
@@ -48,6 +48,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.4" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
The LibreHardwareMonitor package has been added for CPU temperature values.

## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

I think it is important for the user to see the CPU temperature in order to analyse their CPU.

## Reason for the new feature

Yes, it is a new feature that did not exist in the application before. As RunCat365 is an application for managing the computer's CPU/memory, I thought it would be interesting for users to also be able to monitor its temperature. Often, gamers and people who are more knowledgeable about the subject want to know the CPU temperature to see if they need to change the thermal paste, or even optimise their PC in some way.

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.

<img width="162" height="90" alt="imagem_2025-11-05_152225358" src="https://github.com/user-attachments/assets/973a7af7-7149-4a60-bd91-aa03cbe542b6" />

<img width="245" height="386" alt="image" src="https://github.com/user-attachments/assets/0b541e06-2b82-4156-81e4-fbf75700acd8" />