### PR TITLE
fixed bug : Icon disposed exception

### DIFF
--- a/RunCat365/ContextMenuManager.cs
+++ b/RunCat365/ContextMenuManager.cs
@@ -20,7 +20,7 @@ namespace RunCat365
     internal class ContextMenuManager : IDisposable
     {
         private readonly CustomToolStripMenuItem systemInfoMenu = new();
-        private readonly NotifyIcon notifyIcon = new();
+        private NotifyIcon notifyIcon = new();
         private readonly List<Icon> icons = [];
         private readonly object iconLock = new();
         private int current = 0;
@@ -262,7 +262,15 @@ namespace RunCat365
 
         internal void SetNotifyIconText(string text)
         {
-            notifyIcon.Text = text;
+            try
+            {
+                notifyIcon.Text = text;
+            }
+            catch (ObjectDisposedException e)
+            {
+                notifyIcon = new NotifyIcon();
+                notifyIcon.Text = text;
+            }
         }
 
         internal void HideNotifyIcon()


### PR DESCRIPTION
## Context of Contribution

<!-- Each pull request should fix only one issue or propose one feature. -->
<!-- Do not mix unrelated changes in a single PR. -->

- [x] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [ ] Others

## Summary of the Proposal

https://github.com/Kyome22/RunCat365/issues/236

I thought the issue occurred in SetNotifyIconText called from FetchSystemInfo.

To resolve the icon-disposed exception, removed the readonly modifier from the NotifyIcon declaration and added a try-catch block in SetNotifyIconText to reinitialize the notifyIcon.

## Reason for the new feature

-

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.
