### PR TITLE
Add Task Manager launcher

### DIFF
--- a/RunCat365/ContextMenuManager.cs
+++ b/RunCat365/ContextMenuManager.cs
@@ -14,6 +14,7 @@
 
 using RunCat365.Properties;
 using System.ComponentModel;
+using Windows.ApplicationModel;
 
 namespace RunCat365
 {
@@ -44,20 +45,30 @@ namespace RunCat365
             systemInfoMenu.Enabled = false;
 
             var taskManagerMenu = new CustomToolStripMenuItem("Open Task Manager");
-            taskManagerMenu.Click += (sender, e) =>
+            taskManagerMenu.Click += async (sender, e) =>
             {
                 try
                 {
-                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                    {
-                        FileName = "taskmgr",
-                        UseShellExecute = true
-                    });
+                    var fullTrustProcess = FullTrustProcessLauncher.LaunchFullTrustProcessForCurrentAppAsync(
+                        "-fulltrust"
+                    );
+                    await fullTrustProcess;
                 }
-                catch (Exception ex)
+                catch
                 {
-                    MessageBox.Show($"Failed to open Task Manager:\n{ex.Message}", 
-                        "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    try
+                    {
+                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                        {
+                            FileName = "taskmgr",
+                            UseShellExecute = true
+                        });
+                    }
+                    catch (Exception localEx)
+                    {
+                        MessageBox.Show($"Failed to open Task Manager:\n{localEx.Message}", 
+                            "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
                 }
             };
 

--- a/RunCat365/Program.cs
+++ b/RunCat365/Program.cs
@@ -24,6 +24,25 @@ namespace RunCat365
         [STAThread]
         static void Main()
         {
+            var args = Environment.GetCommandLineArgs();
+            if (args.Contains("-fulltrust"))
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "taskmgr",
+                        UseShellExecute = true
+                    });
+                }
+                catch (Exception e)
+                {
+                    MessageBox.Show($"Failed to open Task Manager:\n{e.Message}", 
+                        "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+                return;
+            }
+
             // Terminate RunCat365 if there's any existing instance.
             using var procMutex = new Mutex(true, "_RUNCAT_MUTEX", out var result);
             if (!result) return;


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

This pull request adds a new context menu item “Open Task Manager”, which launches the Windows Task Manager directly from the tray.

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/ef765b63-18f6-49c7-afb7-0a1d2293a707" />

## Reason for the new feature
After checking system performance with RunCat365, users may open Task Manager for further actions, so providing direct access enhances convenience.

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.

## Microsoft Store Approval Requirement (for runFullTrust)

The "Open Task Manager" feature utilizes the FullTrustProcessLauncher API, which requires the runFullTrust Restricted Capability. Please ensure the following administrative steps are taken during the next Microsoft Partner Center submission:
1. Go to the Microsoft Partner Center dashboard and start a New Submission for RunCat365.
2. Upload the new application package containing the runFullTrust capability.
3. Once the package is processed, navigate to the Submission Options page.
4. Locate the "Restricted Capabilities" section that requires justification for runFullTrust.
5. In the required explanation field, copy and paste the detailed justification text provided below:

> Reason for Needing runFullTrust: This capability is required because our application is packaged to use the Full Trust Desktop Application model, which is essential for interacting with certain Windows functions outside of the standard UWP sandbox.
How It Will Be Used: The feature is solely used to launch the standard Windows Task Manager upon a user's explicit selection via the context menu. This action is implemented using the FullTrustProcessLauncher API. We confirm that this capability is not used for any unauthorized system modification or background data access; its sole purpose is to provide quick access to a standard Windows utility, enhancing user convenience.
6. Complete the submission.