### PR TITLE
Add bar indicators

### DIFF
--- a/RunCat365/CPURepository.cs
+++ b/RunCat365/CPURepository.cs
@@ -35,12 +35,21 @@ namespace RunCat365
         {
             var resultLines = new List<string>
             {
-                $"CPU: {cpuInfo.Total:f1}%",
+                $"CPU: {cpuInfo.Total:f1}% {GenerateCpuBar(cpuInfo.Total)}",
                 $"   ├─ User: {cpuInfo.User:f1}%",
                 $"   ├─ Kernel: {cpuInfo.Kernel:f1}%",
                 $"   └─ Available: {cpuInfo.Idle:f1}%"
             };
             return resultLines;
+        }
+
+        private static string GenerateCpuBar(float usagePercent)
+        {
+            const int barLength = 10;
+            int filledLength = (int)(barLength * usagePercent / 100.0f);
+            string filled = new string('▣', filledLength);
+            string empty = new string('□', barLength - filledLength);
+            return filled + empty;
         }
     }
 

--- a/RunCat365/MemoryRepository.cs
+++ b/RunCat365/MemoryRepository.cs
@@ -30,12 +30,21 @@ namespace RunCat365
         {
             var resultLines = new List<string>
             {
-                $"Memory: {memoryInfo.MemoryLoad}%",
+                $"Memory: {memoryInfo.MemoryLoad}% {GenerateMemoryBar(memoryInfo.MemoryLoad)}",
                 $"   ├─ Total: {memoryInfo.TotalMemory.ToByteFormatted()}",
                 $"   ├─ Used: {memoryInfo.UsedMemory.ToByteFormatted()}",
                 $"   └─ Available: {memoryInfo.AvailableMemory.ToByteFormatted()}"
             };
             return resultLines;
+        }
+
+        private static string GenerateMemoryBar(uint usagePercent)
+        {
+            const int barLength = 10;
+            int filledLength = (int)(barLength * usagePercent / 100.0f);
+            string filled = new string('▣', filledLength);
+            string empty = new string('□', barLength - filledLength);
+            return filled + empty;
         }
     }
 

--- a/RunCat365/StorageRepository.cs
+++ b/RunCat365/StorageRepository.cs
@@ -69,12 +69,22 @@ namespace RunCat365
                 var parentPrefix = isLastItem ? "   └─ " : "   ├─ ";
                 var childIndent = isLastItem ? "      " : "   │  ";
                 var percentage = ((double)info.UsedSpaceSize / info.TotalSize) * 100.0;
-                resultLines.Add($"{parentPrefix}{info.Drive.GetString()}: {percentage:f1}%");
+                resultLines.Add($"{parentPrefix}{info.Drive.GetString()}: {percentage:f1}% {GenerateStorageBar(percentage)}");
                 resultLines.Add($"{childIndent}   ├─ Used: {info.UsedSpaceSize.ToByteFormatted()}");
                 resultLines.Add($"{childIndent}   └─ Available: {info.AvailableSpaceSize.ToByteFormatted()}");
             }
 
             return resultLines;
+        }
+
+        private static string GenerateStorageBar(double usagePercent)
+        {
+            const int barLength = 10;
+            int filledLength = (int)(barLength * usagePercent / 100.0f);
+            string filled = new string('▣', filledLength);
+            string empty = new string('□', barLength - filledLength);
+
+            return filled + empty;
         }
     }
 


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

This pull request adds Visual bar indicators for CPU, Memory, and Storage usage.

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/ef765b63-18f6-49c7-afb7-0a1d2293a707" />

## Reason for the new feature

Visualizing resource usage through bar indicators helps users quickly understand the system's status at a glance.

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the Microsoft Store.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.
