### PR TITLE
Add high resource usage alert

### DIFF
--- a/RunCat365/ContextMenuManager.cs
+++ b/RunCat365/ContextMenuManager.cs
@@ -18,8 +18,11 @@ using System.ComponentModel;
 namespace RunCat365
 {
     internal class ContextMenuManager : IDisposable
-    {
-        private readonly CustomToolStripMenuItem systemInfoMenu = new();
+    {        
+        //private readonly CustomToolStripMenuItem systemInfoMenu = new();
+        private readonly ToolStripMenuItem cpuMenuItem = new();
+        private readonly ToolStripMenuItem memoryMenuItem = new();
+        private readonly ToolStripMenuItem storageMenuItem = new();
         private NotifyIcon notifyIcon = new();
         private readonly List<Icon> icons = [];
         private readonly object iconLock = new();
@@ -40,8 +43,6 @@ namespace RunCat365
             Action onExit
         )
         {
-            systemInfoMenu.Text = "-\n-\n-\n-\n-";
-            systemInfoMenu.Enabled = false;
 
             var runnersMenu = new CustomToolStripMenuItem("Runners");
             runnersMenu.SetupSubMenusFromEnum<Runner>(
@@ -130,7 +131,9 @@ namespace RunCat365
 
             var contextMenuStrip = new ContextMenuStrip(new Container());
             contextMenuStrip.Items.AddRange(
-                systemInfoMenu,
+                cpuMenuItem,
+                memoryMenuItem,
+                storageMenuItem,
                 new ToolStripSeparator(),
                 runnersMenu,
                 new ToolStripSeparator(),
@@ -255,9 +258,17 @@ namespace RunCat365
             }
         }
 
-        internal void SetSystemInfoMenuText(string text)
+        internal void SetSystemInfoCpuMenuText(string text)
         {
-            systemInfoMenu.Text = text;
+            cpuMenuItem.Text = text;
+        }
+        internal void SetSystemInfoMemoryMenuText(string text)
+        {
+            memoryMenuItem.Text = text;
+        }
+        internal void SetSystemInfoStorageMenuText(string text)
+        {
+            storageMenuItem.Text = text;
         }
 
         internal void SetNotifyIconText(string text)
@@ -271,6 +282,18 @@ namespace RunCat365
                 notifyIcon = new NotifyIcon();
                 notifyIcon.Text = text;
             }
+        }
+        internal void SetSystemInfoCpuMenuColor(Color color)
+        {
+            cpuMenuItem.ForeColor = color;
+        }
+        internal void SetSystemInfoMemoryMenuColor(Color color)
+        {
+            memoryMenuItem.ForeColor = color;
+        }
+        internal void SetSystemInfoStorageMenuColor(Color color)
+        {
+            storageMenuItem.ForeColor = color;
         }
 
         internal void HideNotifyIcon()

--- a/RunCat365/Program.cs
+++ b/RunCat365/Program.cs
@@ -57,6 +57,7 @@ namespace RunCat365
         private Theme manualTheme = Theme.System;
         private FPSMaxLimit fpsMaxLimit = FPSMaxLimit.FPS40;
         private int fetchCounter = 5;
+        private int cpuRunCounter = 0;
 
         public RunCat365ApplicationContext()
         {
@@ -182,11 +183,29 @@ namespace RunCat365
         {
             contextMenuManager.SetNotifyIconText(cpuInfo.GetDescription());
 
-            var systemInfoValues = new List<string>();
-            systemInfoValues.AddRange(cpuInfo.GenerateIndicator());
-            systemInfoValues.AddRange(memoryInfo.GenerateIndicator());
-            systemInfoValues.AddRange(storageValue.GenerateIndicator());
-            contextMenuManager.SetSystemInfoMenuText(string.Join("\n", [.. systemInfoValues]));
+            // Seperate each context menu 
+            contextMenuManager.SetSystemInfoCpuMenuText(string.Join("\n", cpuInfo.GenerateIndicator()));
+            contextMenuManager.SetSystemInfoMemoryMenuText(string.Join("\n", memoryInfo.GenerateIndicator()));
+            contextMenuManager.SetSystemInfoStorageMenuText(string.Join("\n", storageValue.GenerateIndicator()));
+
+            if (cpuInfo.Total > 80)
+            {
+                cpuRunCounter += 1;
+                if (cpuRunCounter >= 12)
+                    contextMenuManager.SetSystemInfoCpuMenuColor (Color.Red);
+            }
+            else
+                contextMenuManager.SetSystemInfoCpuMenuColor(SystemColors.ControlText);
+
+            if (memoryInfo.MemoryLoad > 80)
+                contextMenuManager.SetSystemInfoMemoryMenuColor(Color.Red);
+            else
+                contextMenuManager.SetSystemInfoMemoryMenuColor(SystemColors.ControlText);
+
+            if (storageValue[0].UsagePercentage > 90.0)
+                contextMenuManager.SetSystemInfoStorageMenuColor(Color.Red);
+            else
+                contextMenuManager.SetSystemInfoStorageMenuColor(SystemColors.ControlText);
         }
 
         private int CalculateInterval(float cpuTotalValue)

--- a/RunCat365/StorageRepository.cs
+++ b/RunCat365/StorageRepository.cs
@@ -49,6 +49,17 @@ namespace RunCat365
         internal long TotalSize { get; set; }
         internal long AvailableSpaceSize { get; set; }
         internal long UsedSpaceSize { get; set; }
+        public double UsagePercentage
+        {
+            get
+            {
+                if (TotalSize == 0)
+                {
+                    return 0.0;
+                }
+                return ((double)UsedSpaceSize / TotalSize) * 100.0;
+            }
+        }
     }
 
     internal static class StorageInfoExtension


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

Added a feature where the menu text turns red under high load conditions to warn the user.
Also refactored `systemInfoMenu` by splitting it into `cpuMenuItem`, `memoryMenuItem`, and `storageMenuItem` components.

### Alert Conditions
- **CPU:** > 80% (sustained for > 1 min)
- **Memory:** > 80%
- **Storage:** > 90%

Since CPU usage is highly volatile, I set a 1 minute threshold to filter out temporary spikes and detect only sustained load.


<img width="272" height="333" alt="image" src="https://github.com/user-attachments/assets/6a110fd8-266c-43ab-9dc9-104474177e5b" />

<img width="272" height="330" alt="image" src="https://github.com/user-attachments/assets/4458655e-4304-4f73-bcc5-913503a7a82c" />

## Reason for the new feature

**Visual highlights** on menu items allow users to check the system load at a glance.


## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the Microsoft Store.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.
