### PR TITLE
feat(i18n): Full localization structure and Korean translation (ko-KR)

### DIFF
--- a/RunCat365/CPURepository.cs
+++ b/RunCat365/CPURepository.cs
@@ -13,6 +13,8 @@
 //    limitations under the License.
 
 using System.Diagnostics;
+using System.Globalization;
+using RunCat365.Properties;
 
 namespace RunCat365
 {
@@ -33,12 +35,18 @@ namespace RunCat365
 
         internal static List<string> GenerateIndicator(this CPUInfo cpuInfo)
         {
+            var cpuLabel = "CPU: ";
+            
+            var userLabel = Resources.ResourceManager.GetString("Info.User", CultureInfo.CurrentUICulture) ?? "User: ";
+            var kernelLabel = Resources.ResourceManager.GetString("Info.Kernel", CultureInfo.CurrentUICulture) ?? "Kernel: ";
+            var availableLabel = Resources.ResourceManager.GetString("Info.Available", CultureInfo.CurrentUICulture) ?? "Available: ";
+
             var resultLines = new List<string>
             {
-                $"CPU: {cpuInfo.Total:f1}%",
-                $"   ├─ User: {cpuInfo.User:f1}%",
-                $"   ├─ Kernel: {cpuInfo.Kernel:f1}%",
-                $"   └─ Available: {cpuInfo.Idle:f1}%"
+                $"{cpuLabel}{cpuInfo.Total:f1}%",
+                $"   ├─ {userLabel}{cpuInfo.User:f1}%",
+                $"   ├─ {kernelLabel}{cpuInfo.Kernel:f1}%",
+                $"   └─ {availableLabel}{cpuInfo.Idle:f1}%"
             };
             return resultLines;
         }

--- a/RunCat365/ContextMenuManager.cs
+++ b/RunCat365/ContextMenuManager.cs
@@ -14,6 +14,7 @@
 
 using RunCat365.Properties;
 using System.ComponentModel;
+using System.Globalization;
 
 namespace RunCat365
 {
@@ -43,7 +44,9 @@ namespace RunCat365
             systemInfoMenu.Text = "-\n-\n-\n-\n-";
             systemInfoMenu.Enabled = false;
 
-            var runnersMenu = new CustomToolStripMenuItem("Runners");
+            var runnersMenu = new CustomToolStripMenuItem(
+                Resources.ResourceManager.GetString("Menu.Runners", CultureInfo.CurrentUICulture) ?? "Runners"
+            );
             runnersMenu.SetupSubMenusFromEnum<Runner>(
                 r => r.GetString(),
                 (parent, sender, e) =>
@@ -60,7 +63,9 @@ namespace RunCat365
                 r => GetRunnerThumbnailBitmap(getSystemTheme(), r)
             );
 
-            var themeMenu = new CustomToolStripMenuItem("Theme");
+            var themeMenu = new CustomToolStripMenuItem(
+                Resources.ResourceManager.GetString("Menu.Theme", CultureInfo.CurrentUICulture) ?? "Theme"
+            );
             themeMenu.SetupSubMenusFromEnum<Theme>(
                 t => t.GetString(),
                 (parent, sender, e) =>
@@ -77,7 +82,9 @@ namespace RunCat365
                 _ => null
             );
 
-            var fpsMaxLimitMenu = new CustomToolStripMenuItem("FPS Max Limit");
+            var fpsMaxLimitMenu = new CustomToolStripMenuItem(
+                Resources.ResourceManager.GetString("Menu.FPSMaxLimit", CultureInfo.CurrentUICulture) ?? "FPS Max Limit"
+            );
             fpsMaxLimitMenu.SetupSubMenusFromEnum<FPSMaxLimit>(
                 f => f.GetString(),
                 (parent, sender, e) =>
@@ -93,22 +100,28 @@ namespace RunCat365
                 _ => null
             );
 
-            var launchAtStartupMenu = new CustomToolStripMenuItem("Launch at startup")
+            var launchAtStartupMenu = new CustomToolStripMenuItem(
+                Resources.ResourceManager.GetString("Menu.LaunchAtStartup", CultureInfo.CurrentUICulture) ?? "Launch at startup"
+            )
             {
                 Checked = getLaunchAtStartup()
             };
             launchAtStartupMenu.Click += (sender, e) => HandleStartupMenuClick(sender, toggleLaunchAtStartup);
-
-            var settingsMenu = new CustomToolStripMenuItem("Settings");
+            
+            var settingsMenu = new CustomToolStripMenuItem(
+                Resources.ResourceManager.GetString("Menu.Settings", CultureInfo.CurrentUICulture) ?? "Settings"
+            );
             settingsMenu.DropDownItems.AddRange(
                 themeMenu,
                 fpsMaxLimitMenu,
                 launchAtStartupMenu
             );
 
-            var endlessGameMenu = new CustomToolStripMenuItem("Endless Game");
+            var endlessGameMenu = new CustomToolStripMenuItem(
+                Resources.ResourceManager.GetString("Menu.EndlessGame", CultureInfo.CurrentUICulture) ?? "Endless Game"
+            );
             endlessGameMenu.Click += (sender, e) => ShowOrActivateGameWindow(getSystemTheme);
-
+            
             var appVersionMenu = new CustomToolStripMenuItem(
                 $"{Application.ProductName} v{Application.ProductVersion}"
             )
@@ -116,16 +129,22 @@ namespace RunCat365
                 Enabled = false
             };
 
-            var repositoryMenu = new CustomToolStripMenuItem("Open Repository");
+            var repositoryMenu = new CustomToolStripMenuItem(
+                Resources.ResourceManager.GetString("Menu.OpenRepository", CultureInfo.CurrentUICulture) ?? "Open Repository"
+            );
             repositoryMenu.Click += (sender, e) => openRepository();
 
-            var informationMenu = new CustomToolStripMenuItem("Information");
+            var informationMenu = new CustomToolStripMenuItem(
+                Resources.ResourceManager.GetString("Menu.Information", CultureInfo.CurrentUICulture) ?? "Information"
+            );
             informationMenu.DropDownItems.AddRange(
                 appVersionMenu,
                 repositoryMenu
             );
 
-            var exitMenu = new CustomToolStripMenuItem("Exit");
+            var exitMenu = new CustomToolStripMenuItem(
+                Resources.ResourceManager.GetString("Menu.Exit", CultureInfo.CurrentUICulture) ?? "Exit"
+            );
             exitMenu.Click += (sender, e) => onExit();
 
             var contextMenuStrip = new ContextMenuStrip(new Container());
@@ -145,11 +164,18 @@ namespace RunCat365
             SetIcons(getSystemTheme(), getManualTheme(), getRunner());
 
             notifyIcon.Text = "-";
-            notifyIcon.Icon = icons[0];
+            if (icons.Count > 0) 
+            {
+                notifyIcon.Icon = icons[0];
+            }
+            else
+            {
+                notifyIcon.Icon = Resources.AppIcon;
+            }
+
             notifyIcon.Visible = true;
             notifyIcon.ContextMenuStrip = contextMenuStrip;
         }
-
         private static void HandleMenuItemSelection<T>(
             ToolStripMenuItem parentMenu,
             object? sender,
@@ -172,15 +198,14 @@ namespace RunCat365
 
         private static Bitmap? GetRunnerThumbnailBitmap(Theme systemTheme, Runner runner)
         {
-            var iconName = $"{systemTheme.GetString()}_{runner.GetString()}_0".ToLower();
+            var iconName = $"{systemTheme.GetResourceName()}_{runner.GetResourceName()}_0".ToLower();
             var obj = Resources.ResourceManager.GetObject(iconName);
             return obj is Icon icon ? icon.ToBitmap() : null;
         }
-
         internal void SetIcons(Theme systemTheme, Theme manualTheme, Runner runner)
         {
-            var prefix = (manualTheme == Theme.System ? systemTheme : manualTheme).GetString();
-            var runnerName = runner.GetString();
+            var prefix = (manualTheme == Theme.System ? systemTheme : manualTheme).GetResourceName();
+            var runnerName = runner.GetResourceName();
             var rm = Resources.ResourceManager;
             var capacity = runner.GetFrameNumber();
             var list = new List<Icon>(capacity);
@@ -191,16 +216,14 @@ namespace RunCat365
                 if (icon is null) continue;
                 list.Add((Icon)icon);
             }
-
             lock (iconLock)
             {
                 icons.ForEach(icon => icon.Dispose());
-                icons.Clear();
-                icons.AddRange(list);
-                current = 0;
+                icons.Clear();                     
+                icons.AddRange(list);                  
+                current = 0;                          
             }
         }
-
         private static void HandleStartupMenuClick(object? sender, Func<bool, bool> toggleLaunchAtStartup)
         {
             if (sender is null) return;
@@ -214,9 +237,9 @@ namespace RunCat365
             }
             catch (InvalidOperationException ex)
             {
-                MessageBox.Show(ex.Message, "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                var warningTitle = Resources.ResourceManager.GetString("Error.Warning", CultureInfo.CurrentUICulture) ?? "Warning";
+                MessageBox.Show(ex.Message, warningTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
-
         }
 
         private void ShowOrActivateGameWindow(Func<Theme> getSystemTheme)
@@ -238,10 +261,11 @@ namespace RunCat365
 
         internal void ShowBalloonTip()
         {
-            var message = "App has launched. " +
-                "If the icon is not on the taskbar, it has been omitted, " +
-                "so please move it manually and pin it.";
-            notifyIcon.ShowBalloonTip(5000, "RunCat 365", message, ToolTipIcon.Info);
+            var message = Resources.ResourceManager.GetString("Notify.Launched", CultureInfo.CurrentUICulture) ?? 
+                          "App has launched. If the icon is not on the taskbar, it has been omitted, so please move it manually and pin it.";
+            var title = Resources.ResourceManager.GetString("Notify.Title", CultureInfo.CurrentUICulture) ?? "RunCat 365";
+
+            notifyIcon.ShowBalloonTip(5000, title, message, ToolTipIcon.Info);
         }
 
         internal void AdvanceFrame()

--- a/RunCat365/LaunchAtStartupManager.cs
+++ b/RunCat365/LaunchAtStartupManager.cs
@@ -14,6 +14,8 @@
 
 using Microsoft.Win32;
 using Windows.ApplicationModel;
+using RunCat365.Properties;
+using System.Globalization;
 
 namespace RunCat365
 {
@@ -38,6 +40,17 @@ namespace RunCat365
         public bool SetEnabled(bool enabled)
         {
             startupTask ??= Task.Run(async () => await StartupTask.GetAsync("RunCatStartup")).Result;
+            if (startupTask is null) return false;
+
+            var culture = CultureInfo.CurrentUICulture;
+
+            var activateFailMessage = Resources.ResourceManager.GetString("Error.LaunchActivateFail", culture) ?? 
+                                      "Launch at Startup could not be activated.";
+            var disabledByUserMessage = Resources.ResourceManager.GetString("Error.LaunchDisabledByUser", culture) ??
+                                        "Launch at startup was disabled by the user, enable it in Task Manager > Startup, search RunCat 365 and enable it.";
+            var disabledByPolicyMessage = Resources.ResourceManager.GetString("Error.LaunchDisabledByPolicy", culture) ??
+                                          "Launch at startup was disabled by policy.";
+                                          
             if (enabled)
             {
                 if (startupTask.State == StartupTaskState.Enabled) startupTask.Disable();
@@ -57,12 +70,12 @@ namespace RunCat365
                         }
                         else
                         {
-                            throw new InvalidOperationException("Launch at Startup could not be activated.");
+                            throw new InvalidOperationException(activateFailMessage);
                         }
                     case StartupTaskState.DisabledByUser:
-                        throw new InvalidOperationException("Launch at startup was disabled by the user, enable it in Task Manager > Startup, search RunCat 365 and enable it.");
+                        throw new InvalidOperationException(disabledByUserMessage);
                     case StartupTaskState.DisabledByPolicy:
-                        throw new InvalidOperationException("Launch at startup was disabled by policy.");
+                        throw new InvalidOperationException(disabledByPolicyMessage);
                     default:
                         return false;
                 }

--- a/RunCat365/MemoryRepository.cs
+++ b/RunCat365/MemoryRepository.cs
@@ -13,6 +13,8 @@
 //    limitations under the License.
 
 using System.Runtime.InteropServices;
+using System.Globalization;
+using RunCat365.Properties;
 
 namespace RunCat365
 {
@@ -28,12 +30,17 @@ namespace RunCat365
     {
         internal static List<string> GenerateIndicator(this MemoryInfo memoryInfo)
         {
+            var memoryLabel = Resources.ResourceManager.GetString("Info.Memory", CultureInfo.CurrentUICulture) ?? "Memory: ";
+            var totalLabel = Resources.ResourceManager.GetString("Info.Total", CultureInfo.CurrentUICulture) ?? "Total: ";
+            var usedLabel = Resources.ResourceManager.GetString("Info.Used", CultureInfo.CurrentUICulture) ?? "Used: ";
+            var availableLabel = Resources.ResourceManager.GetString("Info.Available", CultureInfo.CurrentUICulture) ?? "Available: ";
+
             var resultLines = new List<string>
             {
-                $"Memory: {memoryInfo.MemoryLoad}%",
-                $"   ├─ Total: {memoryInfo.TotalMemory.ToByteFormatted()}",
-                $"   ├─ Used: {memoryInfo.UsedMemory.ToByteFormatted()}",
-                $"   └─ Available: {memoryInfo.AvailableMemory.ToByteFormatted()}"
+                $"{memoryLabel}{memoryInfo.MemoryLoad}%",
+                $"   ├─ {totalLabel}{memoryInfo.TotalMemory.ToByteFormatted()}",
+                $"   ├─ {usedLabel}{memoryInfo.UsedMemory.ToByteFormatted()}",
+                $"   └─ {availableLabel}{memoryInfo.AvailableMemory.ToByteFormatted()}"
             };
             return resultLines;
         }

--- a/RunCat365/Program.cs
+++ b/RunCat365/Program.cs
@@ -99,8 +99,6 @@ namespace RunCat365
             };
             fetchTimer.Tick += new EventHandler(FetchTick);
             fetchTimer.Start();
-
-            ShowBalloonTip();
         }
 
         private static Theme GetSystemTheme()
@@ -172,6 +170,7 @@ namespace RunCat365
         private void AnimationTick(object? sender, EventArgs e)
         {
             contextMenuManager.AdvanceFrame();
+            ShowBalloonTip();
         }
 
         private void FetchSystemInfo(

--- a/RunCat365/Properties/Resources.ko.resx
+++ b/RunCat365/Properties/Resources.ko.resx
@@ -1,0 +1,478 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\app_icon.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  
+  <data name="dark_cat_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\cat\dark_cat_0.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\cat\dark_cat_1.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\cat\dark_cat_2.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_3" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\cat\dark_cat_3.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_4" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\cat\dark_cat_4.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_jumping_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_jumping_0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_jumping_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_jumping_1.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_jumping_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_jumping_2.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_jumping_3" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_jumping_3.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_jumping_4" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_jumping_4.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_jumping_5" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_jumping_5.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_jumping_6" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_jumping_6.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_jumping_7" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_jumping_7.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_jumping_8" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_jumping_8.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_jumping_9" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_jumping_9.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_running_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_running_0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_running_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_running_1.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_running_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_running_2.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_running_3" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_running_3.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_cat_running_4" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_cat_running_4.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_0.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_1.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_2.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_3" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_3.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_4" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_4.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_5" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_5.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_6" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_6.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_7" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_7.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_8" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_8.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_9" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_9.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_10" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_10.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_11" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_11.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_12" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_12.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_horse_13" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\dark_horse_13.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_parrot_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\dark_parrot_0.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_parrot_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\dark_parrot_1.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_parrot_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\dark_parrot_2.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_parrot_3" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\dark_parrot_3.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_parrot_4" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\dark_parrot_4.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_parrot_5" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\dark_parrot_5.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_parrot_6" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\dark_parrot_6.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_parrot_7" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\dark_parrot_7.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_parrot_8" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\dark_parrot_8.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_parrot_9" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\dark_parrot_9.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_road_crater" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_road_crater.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_road_flat" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_road_flat.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_road_hill" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_road_hill.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="dark_road_sprout" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\dark\dark_road_sprout.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\cat\light_cat_0.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\cat\light_cat_1.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\cat\light_cat_2.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_3" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\cat\light_cat_3.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_4" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\cat\light_cat_4.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_jumping_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_jumping_0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_jumping_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_jumping_1.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_jumping_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_jumping_2.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_jumping_3" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_jumping_3.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_jumping_4" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_jumping_4.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_jumping_5" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_jumping_5.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_jumping_6" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_jumping_6.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_jumping_7" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_jumping_7.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_jumping_8" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_jumping_8.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_jumping_9" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_jumping_9.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_running_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_running_0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_running_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_running_1.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_running_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_running_2.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_running_3" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_running_3.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_cat_running_4" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_cat_running_4.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_0.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_1.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_2.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_3" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_3.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_4" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_4.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_5" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_5.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_6" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_6.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_7" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_7.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_8" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_8.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_9" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_9.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_10" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_10.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_11" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_11.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_12" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_12.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_horse_13" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\horse\light_horse_13.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_parrot_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\light_parrot_0.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_parrot_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\light_parrot_1.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_parrot_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\light_parrot_2.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_parrot_3" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\light_parrot_3.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_parrot_4" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\light_parrot_4.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_parrot_5" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\light_parrot_5.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_parrot_6" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\light_parrot_6.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_parrot_7" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\light_parrot_7.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_parrot_8" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\light_parrot_8.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_parrot_9" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\runners\parrot\light_parrot_9.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_road_crater" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_road_crater.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_road_flat" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_road_flat.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_road_hill" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_road_hill.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="light_road_sprout" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\game\light\light_road_sprout.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Menu.Runners" xml:space="preserve">
+    <value>러너</value>
+  </data>
+  <data name="Menu.Theme" xml:space="preserve">
+    <value>테마</value>
+  </data>
+  <data name="Menu.FPSMaxLimit" xml:space="preserve">
+    <value>최대 FPS 제한</value>
+  </data>
+  <data name="Menu.LaunchAtStartup" xml:space="preserve">
+    <value>시작 프로그램에서 실행</value>
+  </data>
+  <data name="Menu.Settings" xml:space="preserve">
+    <value>설정</value>
+  </data>
+  <data name="Menu.EndlessGame" xml:space="preserve">
+    <value>끝없는 달리기 게임</value>
+  </data>
+  <data name="Menu.OpenRepository" xml:space="preserve">
+    <value>저장소 열기</value>
+  </data>
+  <data name="Menu.Information" xml:space="preserve">
+    <value>정보</value>
+  </data>
+  <data name="Menu.Exit" xml:space="preserve">
+    <value>종료</value>
+  </data>
+  <data name="Theme.System" xml:space="preserve">
+    <value>시스템 설정</value>
+  </data>
+  <data name="Theme.Light" xml:space="preserve">
+    <value>라이트</value>
+  </data>
+  <data name="Theme.Dark" xml:space="preserve">
+    <value>다크</value>
+  </data>
+  <data name="Runner.Cat" xml:space="preserve">
+    <value>고양이</value>
+  </data>
+  <data name="Runner.Parrot" xml:space="preserve">
+    <value>앵무새</value>
+  </data>
+  <data name="Runner.Horse" xml:space="preserve">
+    <value>말</value>
+  </data>
+  <data name="Info.User" xml:space="preserve">
+    <value>사용자:</value>
+  </data>
+  <data name="Info.Kernel" xml:space="preserve">
+    <value>커널:</value>
+  </data>
+  <data name="Info.Available" xml:space="preserve">
+    <value>사용 가능:</value>
+  </data>
+  <data name="Info.Memory" xml:space="preserve">
+    <value>메모리:</value>
+  </data>
+  <data name="Info.Total" xml:space="preserve">
+    <value>전체:</value>
+  </data>
+  <data name="Info.Used" xml:space="preserve">
+    <value>사용 중:</value>
+  </data>
+  <data name="Info.Storage" xml:space="preserve">
+    <value>저장소:</value>
+  </data>
+  <data name="Game.Title" xml:space="preserve">
+    <value>끝없는 달리기 게임</value>
+  </data>
+  <data name="Game.Score" xml:space="preserve">
+    <value>점수:</value>
+  </data>
+  <data name="Game.PressSpace" xml:space="preserve">
+    <value>스페이스바를 눌러 시작하세요.</value>
+  </data>
+  <data name="Game.GameOver" xml:space="preserve">
+    <value>게임 오버
+
+</value>
+  </data>
+  <data name="Unit.Byte" xml:space="preserve">
+    <value>B</value>
+  </data>
+  <data name="Unit.KiloByte" xml:space="preserve">
+    <value>KB</value>
+  </data>
+  <data name="Unit.MegaByte" xml:space="preserve">
+    <value>MB</value>
+  </data>
+  <data name="Unit.GigaByte" xml:space="preserve">
+    <value>GB</value>
+  </data>
+  <data name="Unit.TeraByte" xml:space="preserve">
+    <value>TB</value>
+  </data>
+  <data name="Error.Warning" xml:space="preserve">
+    <value>경고</value>
+  </data>
+  <data name="Error.LaunchActivateFail" xml:space="preserve">
+    <value>시작 프로그램 활성화에 실패했습니다.</value>
+  </data>
+  <data name="Error.LaunchDisabledByUser" xml:space="preserve">
+    <value>시작 프로그램은 사용자 설정에 의해 비활성화되어 있습니다. 작업 관리자 &gt; 시작 앱에서 'RunCat 365'를 찾아 직접 활성화해야 합니다.</value>
+  </data>
+  <data name="Error.LaunchDisabledByPolicy" xml:space="preserve">
+    <value>시작 프로그램은 정책에 의해 비활성화되어 있습니다.</value>
+  </data>
+  <data name="Notify.Title" xml:space="preserve">
+    <value>RunCat 365</value>
+  </data>
+  <data name="Notify.Launched" xml:space="preserve">
+    <value>앱이 시작되었습니다. 아이콘이 보이지 않는다면, 작업 표시줄 설정에서 'RunCat 365'를 수동으로 이동시키고 고정하십시오.</value>
+  </data>
+  <data name="Road.Flat" xml:space="preserve">
+    <value>평지</value>
+  </data>
+  <data name="Road.Hill" xml:space="preserve">
+    <value>언덕</value>
+  </data>
+  <data name="Road.Crater" xml:space="preserve">
+    <value>분화구</value>
+  </data>
+  <data name="Road.Sprout" xml:space="preserve">
+    <value>새싹</value>
+  </data>
+</root>

--- a/RunCat365/Runner.cs
+++ b/RunCat365/Runner.cs
@@ -12,6 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+using System.Globalization;
+using RunCat365.Properties;
+
 namespace RunCat365
 {
     enum Runner
@@ -27,13 +30,22 @@ namespace RunCat365
         {
             return runner switch
             {
+                Runner.Cat => Resources.ResourceManager.GetString("Runner.Cat", CultureInfo.CurrentUICulture) ?? "Cat",
+                Runner.Parrot => Resources.ResourceManager.GetString("Runner.Parrot", CultureInfo.CurrentUICulture) ?? "Parrot",
+                Runner.Horse => Resources.ResourceManager.GetString("Runner.Horse", CultureInfo.CurrentUICulture) ?? "Horse",
+                _ => "",
+            };
+        }
+        internal static string GetResourceName(this Runner runner)
+        {
+            return runner switch
+            {
                 Runner.Cat => "Cat",
                 Runner.Parrot => "Parrot",
                 Runner.Horse => "Horse",
                 _ => "",
             };
         }
-
         internal static int GetFrameNumber(this Runner runner)
         {
             return runner switch

--- a/RunCat365/StorageRepository.cs
+++ b/RunCat365/StorageRepository.cs
@@ -11,6 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+using System.Globalization;
+using RunCat365.Properties;
 
 namespace RunCat365
 {
@@ -55,9 +57,13 @@ namespace RunCat365
     {
         internal static List<string> GenerateIndicator(this List<StorageInfo> storageInfoList)
         {
+            var storageHeader = Resources.ResourceManager.GetString("Info.Storage", CultureInfo.CurrentUICulture) ?? "Storage:";
+            var usedLabel = Resources.ResourceManager.GetString("Info.Used", CultureInfo.CurrentUICulture) ?? "Used: ";
+            var availableLabel = Resources.ResourceManager.GetString("Info.Available", CultureInfo.CurrentUICulture) ?? "Available: ";
+
             var resultLines = new List<string>
             {
-                "Storage:"
+                storageHeader
             };
 
             if (storageInfoList.Count == 0) return resultLines;
@@ -70,8 +76,8 @@ namespace RunCat365
                 var childIndent = isLastItem ? "      " : "   │  ";
                 var percentage = ((double)info.UsedSpaceSize / info.TotalSize) * 100.0;
                 resultLines.Add($"{parentPrefix}{info.Drive.GetString()}: {percentage:f1}%");
-                resultLines.Add($"{childIndent}   ├─ Used: {info.UsedSpaceSize.ToByteFormatted()}");
-                resultLines.Add($"{childIndent}   └─ Available: {info.AvailableSpaceSize.ToByteFormatted()}");
+                resultLines.Add($"{childIndent}   ├─ {usedLabel}{info.UsedSpaceSize.ToByteFormatted()}");
+                resultLines.Add($"{childIndent}   └─ {availableLabel}{info.AvailableSpaceSize.ToByteFormatted()}");
             }
 
             return resultLines;

--- a/RunCat365/Theme.cs
+++ b/RunCat365/Theme.cs
@@ -12,6 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+using System.Globalization;
+using RunCat365.Properties;
+
 namespace RunCat365
 {
     enum Theme
@@ -24,6 +27,16 @@ namespace RunCat365
     internal static class ThemeExtension
     {
         internal static string GetString(this Theme theme)
+        {
+            return theme switch
+            {
+                Theme.System => Resources.ResourceManager.GetString("Theme.System", CultureInfo.CurrentUICulture) ?? "System",
+                Theme.Light => Resources.ResourceManager.GetString("Theme.Light", CultureInfo.CurrentUICulture) ?? "Light",
+                Theme.Dark => Resources.ResourceManager.GetString("Theme.Dark", CultureInfo.CurrentUICulture) ?? "Dark",
+                _ => "",
+            };
+        }
+        internal static string GetResourceName(this Theme theme)
         {
             return theme switch
             {


### PR DESCRIPTION
## Context of Contribution

<!-- Each pull request should fix only one issue or propose one feature. -->
<!-- Do not mix unrelated changes in a single PR. -->

- [ ] Bug Fix
- [x] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

This Pull Request (PR) achieves two goals by resolving Issue #225 and introducing the Korean language (ko-KR).

Implements a robust internationalization (I18n) structure by removing all hardcoded English UI strings across the application.

Adds Korean localization via Resources.ko.resx

## Reason for the new feature

The main reason for this change is to enable localization for the project as requested in Issue #225, thereby making the app accessible to a wider global audience.

Key Structural Justification:

The original app had numerous hardcoded strings used for menu items and system information labels, making community translation contributions impossible.

The code is refactored to dynamically load all strings from .resx files based on the user's system culture.

## Technical Details & Bug Fixes
Logic Separation Fix: Solved the critical animation bug where the resource manager failed to load runner icons (dark_cat_0, etc.) because the code was incorrectly searching for localized resource keys (e.g., "다크_고양이_0") instead of the required English keys ("dark_cat_0").

This was fixed by implementing separate extension methods (GetString for display and GetResourceName for internal resource lookups) in Theme.cs and Runner.cs.

Icon Loading: Animation icon references are now successfully loaded from the default Resources.resx using the fallback mechanism, allowing the animation to display correctly alongside Korean text.

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [ ] Implemented using only APIs that can be submitted to the Microsoft Store.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.
<img width="295" height="394" alt="KakaoTalk_20251121_112234871" src="https://github.com/user-attachments/assets/b518f74c-31cb-4ee9-8e66-f9cd3061fa71" />


