### PR TITLE
fixed bug: Changed to regenerate the NotifyIcon when the computer resumes

### DIFF
--- a/RunCat365/ContextMenuManager.cs
+++ b/RunCat365/ContextMenuManager.cs
@@ -298,7 +298,7 @@ namespace RunCat365
             {
                 notifyIcon.Text = text;
             }
-            catch(ObjectDisposedException)
+            catch (ObjectDisposedException)
             {
                 RecreateNotifyIcon();
             }


### PR DESCRIPTION
## Context of Contribution

<!-- Each pull request should fix only one issue or propose one feature. -->
<!-- Do not mix unrelated changes in a single PR. -->

- [x] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [ ] Others

## Summary of the Proposal

As I mentioned in my comment on Pull Request #241, it seems that this error occurs when the PC wakes up from sleep.
Therefore, I modified the code to recreate the NotifyIcon upon resume and when an ObjectDisposedException is thrown.
I have been using this code for about two weeks, and no exceptions have occurred during that time.

## Reason for the new feature

no new feature

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the Microsoft Store.
- [x] Works correctly in both dark theme and light theme.
- [ ] Works correctly on any device.
