### PR TITLE
Fix disposed icon crash

### DIFF
--- a/RunCat365/ContextMenuManager.cs
+++ b/RunCat365/ContextMenuManager.cs
@@ -194,8 +194,6 @@ namespace RunCat365
 
             lock (iconLock)
             {
-                // Don't dispose icons from ResourceManager - they are managed resources
-                // Disposing them causes ObjectDisposedException when NotifyIcon tries to access them
                 icons.Clear();
                 icons.AddRange(list);
                 current = 0;
@@ -283,7 +281,6 @@ namespace RunCat365
             {
                 lock (iconLock)
                 {
-                    // Don't dispose icons from ResourceManager - they are managed resources
                     icons.Clear();
                 }
 


### PR DESCRIPTION
## Context of Contribution

<!-- Each pull request should fix only one issue or propose one feature. -->
<!-- Do not mix unrelated changes in a single PR. -->

- [x] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [ ] Others

fix #236

## Summary of the Proposal

<!-- Provide a concise summary of what this pull request proposes. -->

Since I have established a way to reproduce the issue, I have identified the cause and fixed it. 
There is no need to manually dispose of the NotifyIcon's Icon.

## Reason for the new feature

<!-- If it's a new feature, explain why this feature is necessary. -->
<!-- Explain how important this feature is to many users. -->
<!-- Explain if the benefits of the new feature outweigh the maintenance cost. -->

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the Microsoft Store.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.
