### PR TITLE
Set CurrentCulture to match UI language for locale-aware number formatting

### DIFF
--- a/RunCat365/Program.cs
+++ b/RunCat365/Program.cs
@@ -29,6 +29,7 @@ namespace RunCat365
             // Specify language manually.
             CultureInfo.CurrentUICulture = SupportedLanguage.English.GetDefaultCultureInfo();
 #endif
+            CultureInfo.CurrentCulture = SupportedLanguageExtension.GetCurrentLanguage().GetDefaultCultureInfo();
 
             // Terminate RunCat365 if there's any existing instance.
             using var procMutex = new Mutex(true, "_RUNCAT_MUTEX", out var result);


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

Set `CultureInfo.CurrentCulture` at startup to match the current UI language, so that number formatting (decimal separator, etc.) follows the display language's conventions.

## Reason for the new feature

Spanish localization was recently added, but Spanish uses a comma as the decimal separator (e.g. `85,3%`, `1,5 GB`) rather than a period. Previously, number formatting always followed the Windows system regional settings, independent of the app's UI language. This meant users running a Spanish UI on an English-configured system would still see period-separated numbers, which is incorrect.

.NET separates UI language (`CurrentUICulture`) from number/date formatting (`CurrentCulture`). By explicitly setting `CurrentCulture` to the culture that corresponds to the selected UI language, the app now behaves consistently — the same way iOS automatically ties number formatting to the active Locale.

This is a one-line change that reuses the existing `SupportedLanguageExtension.GetDefaultCultureInfo()` utility, with no modifications needed to `ByteFormatter` or the Repository classes.

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the Microsoft Store.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.