### PR TITLE
Add Traditional Chinese (zh-TW) localization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,17 +70,17 @@ This is a Windows Forms application (.NET 9.0 / C#) for Microsoft Store distribu
 - `Properties/UserSettings.settings` - User preferences (Runner, Theme, SpeedSource, FPSMaxLimit)
 - `Properties/Resources.resx` - Embedded images and icons
 - `Properties/Strings.resx` - Localized strings (English default);
-  - `Strings.ja.resx` (Japanese)
-  - `Strings.es.resx` (Spanish)
+  - `Strings.zh-CN.resx` (Chinese (simplified))
+  - `Strings.zh-TW.resx` (Chinese (traditional))
   - `Strings.fr.resx` (French)
   - `Strings.de.resx` (German)
-  - `Strings.zh-CN.resx` (Simplified Chinese)
-  - `Strings.zh-TW.resx` (Traditional Chinese)
+  - `Strings.ja.resx` (Japanese)
+  - `Strings.es.resx` (Spanish)
 
 **Localization notes:**
 
 - Add new strings to all seven `.resx` files simultaneously
-- Japanese uses "Noto Sans JP" font; Simplified Chinese uses "Microsoft YaHei" font; Traditional Chinese uses "Microsoft JhengHei" font; English/Spanish/French/German use "Consolas"
+- Japanese uses "Noto Sans JP" font; Chinese (simplified) uses "Microsoft YaHei" font; Chinese (traditional) uses "Microsoft JhengHei" font; English/Spanish/French/German use "Consolas"
 
 ## Coding Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,11 +75,12 @@ This is a Windows Forms application (.NET 9.0 / C#) for Microsoft Store distribu
   - `Strings.fr.resx` (French)
   - `Strings.de.resx` (German)
   - `Strings.zh-CN.resx` (Simplified Chinese)
+  - `Strings.zh-TW.resx` (Traditional Chinese)
 
 **Localization notes:**
 
-- Add new strings to all six `.resx` files simultaneously
-- Japanese uses "Noto Sans JP" font; Simplified Chinese uses "Microsoft YaHei" font; English/Spanish/French/German use "Consolas"
+- Add new strings to all seven `.resx` files simultaneously
+- Japanese uses "Noto Sans JP" font; Simplified Chinese uses "Microsoft YaHei" font; Traditional Chinese uses "Microsoft JhengHei" font; English/Spanish/French/German use "Consolas"
 
 ## Coding Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,10 @@ This is a Windows Forms application (.NET 9.0 / C#) for Microsoft Store distribu
 **Localization notes:**
 
 - Add new strings to all seven `.resx` files simultaneously
-- Japanese uses "Noto Sans JP" font; Chinese (simplified) uses "Microsoft YaHei" font; Chinese (traditional) uses "Microsoft JhengHei" font; English/Spanish/French/German use "Consolas"
+- English/Spanish/French/German use "Consolas"
+- Japanese uses "Noto Sans JP" font
+- Chinese (simplified) uses "Microsoft YaHei" font
+- Chinese (traditional) uses "Microsoft JhengHei" font
 
 ## Coding Rules
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ RunCat 365 is available for installation on the Microsoft Store.
 - Requirement: Windows 10 version 19041.0 or higher
 - Microsoft Store: https://apps.microsoft.com/detail/9nw5lpnvwfwj
 - Language:
+  - Chinese (simplified)
+  - Chinese (traditional)
   - English (default)
-  - Japanese
-  - Spanish
   - French
   - German
+  - Japanese
+  - Spanish
 
 ## Contributors
 

--- a/RunCat365/Program.cs
+++ b/RunCat365/Program.cs
@@ -25,12 +25,12 @@ namespace RunCat365
         [STAThread]
         static void Main()
         {
-            var defaultCultureInfo = SupportedLanguageExtension.GetCurrentLanguage().GetDefaultCultureInfo();
 #if DEBUG
-            CultureInfo.CurrentUICulture = SupportedLanguage.English.GetDefaultCultureInfo();
+            var defaultCultureInfo = SupportedLanguage.English.GetDefaultCultureInfo();
 #else
-            CultureInfo.CurrentUICulture = defaultCultureInfo;
+            var defaultCultureInfo = SupportedLanguageExtension.GetCurrentLanguage().GetDefaultCultureInfo();
 #endif
+            CultureInfo.CurrentUICulture = defaultCultureInfo;
             CultureInfo.CurrentCulture = defaultCultureInfo;
 
             // Terminate RunCat365 if there's any existing instance.

--- a/RunCat365/Program.cs
+++ b/RunCat365/Program.cs
@@ -25,11 +25,13 @@ namespace RunCat365
         [STAThread]
         static void Main()
         {
+            var defaultCultureInfo = SupportedLanguageExtension.GetCurrentLanguage().GetDefaultCultureInfo();
 #if DEBUG
-            // Specify language manually.
             CultureInfo.CurrentUICulture = SupportedLanguage.English.GetDefaultCultureInfo();
+#else
+            CultureInfo.CurrentUICulture = defaultCultureInfo;
 #endif
-            CultureInfo.CurrentCulture = SupportedLanguageExtension.GetCurrentLanguage().GetDefaultCultureInfo();
+            CultureInfo.CurrentCulture = defaultCultureInfo;
 
             // Terminate RunCat365 if there's any existing instance.
             using var procMutex = new Mutex(true, "_RUNCAT_MUTEX", out var result);

--- a/RunCat365/Properties/Strings.zh-CN.resx
+++ b/RunCat365/Properties/Strings.zh-CN.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
+  <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,180 +59,179 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="metadata">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" />
-							</xsd:sequence>
-							<xsd:attribute name="name" use="required" type="xsd:string" />
-							<xsd:attribute name="type" type="xsd:string" />
-							<xsd:attribute name="mimetype" type="xsd:string" />
-							<xsd:attribute ref="xml:space" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="assembly">
-						<xsd:complexType>
-							<xsd:attribute name="alias" type="xsd:string" />
-							<xsd:attribute name="name" type="xsd:string" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-							<xsd:attribute ref="xml:space" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>2.0</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<data name="Menu_Runner" xml:space="preserve">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Menu_Runner" xml:space="preserve">
     <value>跑步者</value>
   </data>
-	<data name="Menu_Theme" xml:space="preserve">
+  <data name="Menu_Theme" xml:space="preserve">
     <value>主题</value>
   </data>
-	<data name="Menu_FPSMaxLimit" xml:space="preserve">
+  <data name="Menu_FPSMaxLimit" xml:space="preserve">
     <value>FPS 最大限制</value>
   </data>
-	<data name="Menu_LaunchAtStartup" xml:space="preserve">
+  <data name="Menu_LaunchAtStartup" xml:space="preserve">
     <value>跟随 Windows 启动</value>
   </data>
-	<data name="Menu_Settings" xml:space="preserve">
+  <data name="Menu_Settings" xml:space="preserve">
     <value>设置</value>
   </data>
-	<data name="Menu_EndlessGame" xml:space="preserve">
+  <data name="Menu_EndlessGame" xml:space="preserve">
     <value>无尽游戏</value>
   </data>
-	<data name="Menu_Information" xml:space="preserve">
+  <data name="Menu_Information" xml:space="preserve">
     <value>信息</value>
   </data>
-	<data name="Menu_OpenRepository" xml:space="preserve">
+  <data name="Menu_OpenRepository" xml:space="preserve">
     <value>打开存储库</value>
   </data>
-	<data name="Menu_Exit" xml:space="preserve">
+  <data name="Menu_Exit" xml:space="preserve">
     <value>退出</value>
   </data>
-	<data name="Theme_System" xml:space="preserve">
+  <data name="Theme_System" xml:space="preserve">
     <value>系统</value>
   </data>
-	<data name="Theme_Light" xml:space="preserve">
+  <data name="Theme_Light" xml:space="preserve">
     <value>浅色</value>
   </data>
-	<data name="Theme_Dark" xml:space="preserve">
+  <data name="Theme_Dark" xml:space="preserve">
     <value>深色</value>
   </data>
-	<data name="Runner_Cat" xml:space="preserve">
+  <data name="Runner_Cat" xml:space="preserve">
     <value>猫咪</value>
   </data>
-	<data name="Runner_Parrot" xml:space="preserve">
+  <data name="Runner_Parrot" xml:space="preserve">
     <value>鹦鹉</value>
   </data>
-	<data name="Runner_Horse" xml:space="preserve">
+  <data name="Runner_Horse" xml:space="preserve">
     <value>马</value>
   </data>
-	<data name="Message_AppLaunched" xml:space="preserve">
+  <data name="Message_AppLaunched" xml:space="preserve">
     <value>应用已启动。如果图标不在任务栏上，则表示该应用已被省略，请手动移动并将其固定。</value>
   </data>
-	<data name="Message_Warning" xml:space="preserve">
+  <data name="Message_Warning" xml:space="preserve">
     <value>警告</value>
   </data>
-	<data name="Window_EndlessGame" xml:space="preserve">
+  <data name="Window_EndlessGame" xml:space="preserve">
     <value>无尽游戏</value>
   </data>
-	<data name="Game_PressSpaceToPlay" xml:space="preserve">
+  <data name="Game_PressSpaceToPlay" xml:space="preserve">
     <value>按空格键开始。</value>
   </data>
-	<data name="Game_GameOver" xml:space="preserve">
+  <data name="Game_GameOver" xml:space="preserve">
     <value>游戏结束</value>
   </data>
-	<data name="SystemInfo_CPU" xml:space="preserve">
+  <data name="SystemInfo_CPU" xml:space="preserve">
     <value>CPU</value>
   </data>
-	<data name="SystemInfo_User" xml:space="preserve">
+  <data name="SystemInfo_User" xml:space="preserve">
     <value>用户</value>
   </data>
-	<data name="SystemInfo_Kernel" xml:space="preserve">
+  <data name="SystemInfo_Kernel" xml:space="preserve">
     <value>内核</value>
   </data>
-	<data name="SystemInfo_Available" xml:space="preserve">
+  <data name="SystemInfo_Available" xml:space="preserve">
     <value>可用</value>
   </data>
-	<data name="SystemInfo_GPU" xml:space="preserve">
+  <data name="SystemInfo_GPU" xml:space="preserve">
     <value>GPU</value>
   </data>
-	<data name="SystemInfo_Average" xml:space="preserve">
+  <data name="SystemInfo_Average" xml:space="preserve">
     <value>平均</value>
   </data>
-	<data name="SystemInfo_Maximum" xml:space="preserve">
+  <data name="SystemInfo_Maximum" xml:space="preserve">
     <value>最大</value>
   </data>
-	<data name="SystemInfo_Memory" xml:space="preserve">
+  <data name="SystemInfo_Memory" xml:space="preserve">
     <value>内存</value>
   </data>
-	<data name="SystemInfo_Total" xml:space="preserve">
+  <data name="SystemInfo_Total" xml:space="preserve">
     <value>总计</value>
   </data>
-	<data name="SystemInfo_Used" xml:space="preserve">
+  <data name="SystemInfo_Used" xml:space="preserve">
     <value>已使用</value>
   </data>
-	<data name="SystemInfo_Storage" xml:space="preserve">
+  <data name="SystemInfo_Storage" xml:space="preserve">
     <value>存储</value>
   </data>
-	<data name="SystemInfo_DriveC" xml:space="preserve">
+  <data name="SystemInfo_DriveC" xml:space="preserve">
     <value>C 盘</value>
   </data>
-	<data name="SystemInfo_DriveD" xml:space="preserve">
+  <data name="SystemInfo_DriveD" xml:space="preserve">
     <value>D 盘</value>
   </data>
-	<data name="SystemInfo_Network" xml:space="preserve">
+  <data name="SystemInfo_Network" xml:space="preserve">
     <value>网络</value>
   </data>
-	<data name="SystemInfo_Sent" xml:space="preserve">
+  <data name="SystemInfo_Sent" xml:space="preserve">
     <value>发送</value>
   </data>
-	<data name="SystemInfo_Received" xml:space="preserve">
+  <data name="SystemInfo_Received" xml:space="preserve">
     <value>已接收</value>
   </data>
-	<data name="Message_CPUUsageUnavailable" xml:space="preserve">
+  <data name="Message_CPUUsageUnavailable" xml:space="preserve">
     <value>获取 CPU 使用率失败。无法更新运行速度。</value>
   </data>
-	<data name="Menu_SpeedSource" xml:space="preserve">
+  <data name="Menu_SpeedSource" xml:space="preserve">
     <value>速度来源</value>
   </data>
-	<data name="Game_NewRecord" xml:space="preserve">
+  <data name="Game_NewRecord" xml:space="preserve">
     <value>新纪录</value>
   </data>
-
 </root>

--- a/RunCat365/Properties/Strings.zh-TW.resx
+++ b/RunCat365/Properties/Strings.zh-TW.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,212 +26,212 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="metadata">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" />
-							</xsd:sequence>
-							<xsd:attribute name="name" use="required" type="xsd:string" />
-							<xsd:attribute name="type" type="xsd:string" />
-							<xsd:attribute name="mimetype" type="xsd:string" />
-							<xsd:attribute ref="xml:space" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="assembly">
-						<xsd:complexType>
-							<xsd:attribute name="alias" type="xsd:string" />
-							<xsd:attribute name="name" type="xsd:string" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-							<xsd:attribute ref="xml:space" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>2.0</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<data name="Menu_Runner" xml:space="preserve">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Menu_Runner" xml:space="preserve">
     <value>跑步者</value>
   </data>
-	<data name="Menu_Theme" xml:space="preserve">
+  <data name="Menu_Theme" xml:space="preserve">
     <value>主題</value>
   </data>
-	<data name="Menu_FPSMaxLimit" xml:space="preserve">
+  <data name="Menu_FPSMaxLimit" xml:space="preserve">
     <value>FPS 最大限制</value>
   </data>
-	<data name="Menu_LaunchAtStartup" xml:space="preserve">
+  <data name="Menu_LaunchAtStartup" xml:space="preserve">
     <value>跟隨 Windows 啟動</value>
   </data>
-	<data name="Menu_Settings" xml:space="preserve">
+  <data name="Menu_Settings" xml:space="preserve">
     <value>設定</value>
   </data>
-	<data name="Menu_EndlessGame" xml:space="preserve">
+  <data name="Menu_EndlessGame" xml:space="preserve">
     <value>無盡遊戲</value>
   </data>
-	<data name="Menu_Information" xml:space="preserve">
+  <data name="Menu_Information" xml:space="preserve">
     <value>資訊</value>
   </data>
-	<data name="Menu_OpenRepository" xml:space="preserve">
+  <data name="Menu_OpenRepository" xml:space="preserve">
     <value>開啟存儲庫</value>
   </data>
-	<data name="Menu_Exit" xml:space="preserve">
+  <data name="Menu_Exit" xml:space="preserve">
     <value>結束</value>
   </data>
-	<data name="Theme_System" xml:space="preserve">
+  <data name="Theme_System" xml:space="preserve">
     <value>系統</value>
   </data>
-	<data name="Theme_Light" xml:space="preserve">
+  <data name="Theme_Light" xml:space="preserve">
     <value>淺色</value>
   </data>
-	<data name="Theme_Dark" xml:space="preserve">
+  <data name="Theme_Dark" xml:space="preserve">
     <value>深色</value>
   </data>
-	<data name="Runner_Cat" xml:space="preserve">
+  <data name="Runner_Cat" xml:space="preserve">
     <value>貓咪</value>
   </data>
-	<data name="Runner_Parrot" xml:space="preserve">
+  <data name="Runner_Parrot" xml:space="preserve">
     <value>鸚鵡</value>
   </data>
-	<data name="Runner_Horse" xml:space="preserve">
+  <data name="Runner_Horse" xml:space="preserve">
     <value>馬</value>
   </data>
-	<data name="Message_AppLaunched" xml:space="preserve">
+  <data name="Message_AppLaunched" xml:space="preserve">
     <value>應用程式已啟動。如果圖示不在工作列上，表示已被省略，請手動移動並固定它。</value>
   </data>
-	<data name="Message_Warning" xml:space="preserve">
+  <data name="Message_Warning" xml:space="preserve">
     <value>警告</value>
   </data>
-	<data name="Window_EndlessGame" xml:space="preserve">
+  <data name="Window_EndlessGame" xml:space="preserve">
     <value>無盡遊戲</value>
   </data>
-	<data name="Game_PressSpaceToPlay" xml:space="preserve">
+  <data name="Game_PressSpaceToPlay" xml:space="preserve">
     <value>按空白鍵開始。</value>
   </data>
-	<data name="Game_GameOver" xml:space="preserve">
+  <data name="Game_GameOver" xml:space="preserve">
     <value>遊戲結束</value>
   </data>
-	<data name="SystemInfo_CPU" xml:space="preserve">
+  <data name="SystemInfo_CPU" xml:space="preserve">
     <value>CPU</value>
   </data>
-	<data name="SystemInfo_User" xml:space="preserve">
+  <data name="SystemInfo_User" xml:space="preserve">
     <value>使用者</value>
   </data>
-	<data name="SystemInfo_Kernel" xml:space="preserve">
+  <data name="SystemInfo_Kernel" xml:space="preserve">
     <value>核心</value>
   </data>
-	<data name="SystemInfo_Available" xml:space="preserve">
+  <data name="SystemInfo_Available" xml:space="preserve">
     <value>可用</value>
   </data>
-	<data name="SystemInfo_GPU" xml:space="preserve">
+  <data name="SystemInfo_GPU" xml:space="preserve">
     <value>GPU</value>
   </data>
-	<data name="SystemInfo_Average" xml:space="preserve">
+  <data name="SystemInfo_Average" xml:space="preserve">
     <value>平均</value>
   </data>
-	<data name="SystemInfo_Maximum" xml:space="preserve">
+  <data name="SystemInfo_Maximum" xml:space="preserve">
     <value>最大</value>
   </data>
-	<data name="SystemInfo_Memory" xml:space="preserve">
+  <data name="SystemInfo_Memory" xml:space="preserve">
     <value>記憶體</value>
   </data>
-	<data name="SystemInfo_Total" xml:space="preserve">
+  <data name="SystemInfo_Total" xml:space="preserve">
     <value>總計</value>
   </data>
-	<data name="SystemInfo_Used" xml:space="preserve">
+  <data name="SystemInfo_Used" xml:space="preserve">
     <value>已使用</value>
   </data>
-	<data name="SystemInfo_Storage" xml:space="preserve">
+  <data name="SystemInfo_Storage" xml:space="preserve">
     <value>儲存</value>
   </data>
-	<data name="SystemInfo_DriveC" xml:space="preserve">
+  <data name="SystemInfo_DriveC" xml:space="preserve">
     <value>C 槽</value>
   </data>
-	<data name="SystemInfo_DriveD" xml:space="preserve">
+  <data name="SystemInfo_DriveD" xml:space="preserve">
     <value>D 槽</value>
   </data>
-	<data name="SystemInfo_Network" xml:space="preserve">
+  <data name="SystemInfo_Network" xml:space="preserve">
     <value>網路</value>
   </data>
-	<data name="SystemInfo_Sent" xml:space="preserve">
+  <data name="SystemInfo_Sent" xml:space="preserve">
     <value>傳送</value>
   </data>
-	<data name="SystemInfo_Received" xml:space="preserve">
+  <data name="SystemInfo_Received" xml:space="preserve">
     <value>已接收</value>
   </data>
-	<data name="Message_CPUUsageUnavailable" xml:space="preserve">
+  <data name="Message_CPUUsageUnavailable" xml:space="preserve">
     <value>取得 CPU 使用率失敗。無法更新執行速度。</value>
   </data>
-	<data name="Menu_SpeedSource" xml:space="preserve">
+  <data name="Menu_SpeedSource" xml:space="preserve">
     <value>速度來源</value>
   </data>
-	<data name="Game_NewRecord" xml:space="preserve">
+  <data name="Game_NewRecord" xml:space="preserve">
     <value>新紀錄</value>
   </data>
 </root>

--- a/RunCat365/Properties/Strings.zh-TW.resx
+++ b/RunCat365/Properties/Strings.zh-TW.resx
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+		<xsd:element name="root" msdata:IsDataSet="true">
+			<xsd:complexType>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="metadata">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" />
+							</xsd:sequence>
+							<xsd:attribute name="name" use="required" type="xsd:string" />
+							<xsd:attribute name="type" type="xsd:string" />
+							<xsd:attribute name="mimetype" type="xsd:string" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="assembly">
+						<xsd:complexType>
+							<xsd:attribute name="alias" type="xsd:string" />
+							<xsd:attribute name="name" type="xsd:string" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="data">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="resheader">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:complexType>
+		</xsd:element>
+	</xsd:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="Menu_Runner" xml:space="preserve">
+    <value>跑步者</value>
+  </data>
+	<data name="Menu_Theme" xml:space="preserve">
+    <value>主題</value>
+  </data>
+	<data name="Menu_FPSMaxLimit" xml:space="preserve">
+    <value>FPS 最大限制</value>
+  </data>
+	<data name="Menu_LaunchAtStartup" xml:space="preserve">
+    <value>跟隨 Windows 啟動</value>
+  </data>
+	<data name="Menu_Settings" xml:space="preserve">
+    <value>設定</value>
+  </data>
+	<data name="Menu_EndlessGame" xml:space="preserve">
+    <value>無盡遊戲</value>
+  </data>
+	<data name="Menu_Information" xml:space="preserve">
+    <value>資訊</value>
+  </data>
+	<data name="Menu_OpenRepository" xml:space="preserve">
+    <value>開啟存儲庫</value>
+  </data>
+	<data name="Menu_Exit" xml:space="preserve">
+    <value>結束</value>
+  </data>
+	<data name="Theme_System" xml:space="preserve">
+    <value>系統</value>
+  </data>
+	<data name="Theme_Light" xml:space="preserve">
+    <value>淺色</value>
+  </data>
+	<data name="Theme_Dark" xml:space="preserve">
+    <value>深色</value>
+  </data>
+	<data name="Runner_Cat" xml:space="preserve">
+    <value>貓咪</value>
+  </data>
+	<data name="Runner_Parrot" xml:space="preserve">
+    <value>鸚鵡</value>
+  </data>
+	<data name="Runner_Horse" xml:space="preserve">
+    <value>馬</value>
+  </data>
+	<data name="Message_AppLaunched" xml:space="preserve">
+    <value>應用程式已啟動。如果圖示不在工作列上，表示已被省略，請手動移動並固定它。</value>
+  </data>
+	<data name="Message_Warning" xml:space="preserve">
+    <value>警告</value>
+  </data>
+	<data name="Window_EndlessGame" xml:space="preserve">
+    <value>無盡遊戲</value>
+  </data>
+	<data name="Game_PressSpaceToPlay" xml:space="preserve">
+    <value>按空白鍵開始。</value>
+  </data>
+	<data name="Game_GameOver" xml:space="preserve">
+    <value>遊戲結束</value>
+  </data>
+	<data name="SystemInfo_CPU" xml:space="preserve">
+    <value>CPU</value>
+  </data>
+	<data name="SystemInfo_User" xml:space="preserve">
+    <value>使用者</value>
+  </data>
+	<data name="SystemInfo_Kernel" xml:space="preserve">
+    <value>核心</value>
+  </data>
+	<data name="SystemInfo_Available" xml:space="preserve">
+    <value>可用</value>
+  </data>
+	<data name="SystemInfo_GPU" xml:space="preserve">
+    <value>GPU</value>
+  </data>
+	<data name="SystemInfo_Average" xml:space="preserve">
+    <value>平均</value>
+  </data>
+	<data name="SystemInfo_Maximum" xml:space="preserve">
+    <value>最大</value>
+  </data>
+	<data name="SystemInfo_Memory" xml:space="preserve">
+    <value>記憶體</value>
+  </data>
+	<data name="SystemInfo_Total" xml:space="preserve">
+    <value>總計</value>
+  </data>
+	<data name="SystemInfo_Used" xml:space="preserve">
+    <value>已使用</value>
+  </data>
+	<data name="SystemInfo_Storage" xml:space="preserve">
+    <value>儲存</value>
+  </data>
+	<data name="SystemInfo_DriveC" xml:space="preserve">
+    <value>C 槽</value>
+  </data>
+	<data name="SystemInfo_DriveD" xml:space="preserve">
+    <value>D 槽</value>
+  </data>
+	<data name="SystemInfo_Network" xml:space="preserve">
+    <value>網路</value>
+  </data>
+	<data name="SystemInfo_Sent" xml:space="preserve">
+    <value>傳送</value>
+  </data>
+	<data name="SystemInfo_Received" xml:space="preserve">
+    <value>已接收</value>
+  </data>
+	<data name="Message_CPUUsageUnavailable" xml:space="preserve">
+    <value>取得 CPU 使用率失敗。無法更新執行速度。</value>
+  </data>
+	<data name="Menu_SpeedSource" xml:space="preserve">
+    <value>速度來源</value>
+  </data>
+	<data name="Game_NewRecord" xml:space="preserve">
+    <value>新紀錄</value>
+  </data>
+</root>

--- a/RunCat365/SupportedLanguage.cs
+++ b/RunCat365/SupportedLanguage.cs
@@ -24,6 +24,7 @@ namespace RunCat365
         French,
         German,
         SimplifiedChinese,
+        TraditionalChinese,
     }
 
     internal static class SupportedLanguageExtension
@@ -37,9 +38,16 @@ namespace RunCat365
                 "es" => SupportedLanguage.Spanish,
                 "fr" => SupportedLanguage.French,
                 "de" => SupportedLanguage.German,
-                "zh" => SupportedLanguage.SimplifiedChinese,
+                "zh" => DetectChineseVariant(culture),
                 _ => SupportedLanguage.English,
             };
+        }
+
+        private static SupportedLanguage DetectChineseVariant(CultureInfo culture)
+        {
+            return culture.Name.Contains("Hant") || culture.Name is "zh-TW" or "zh-HK" or "zh-MO"
+                ? SupportedLanguage.TraditionalChinese
+                : SupportedLanguage.SimplifiedChinese;
         }
 
         internal static CultureInfo GetDefaultCultureInfo(this SupportedLanguage language)
@@ -51,6 +59,7 @@ namespace RunCat365
                 SupportedLanguage.French => new CultureInfo("fr-FR"),
                 SupportedLanguage.German => new CultureInfo("de-DE"),
                 SupportedLanguage.SimplifiedChinese => new CultureInfo("zh-CN"),
+                SupportedLanguage.TraditionalChinese => new CultureInfo("zh-TW"),
                 _ => new CultureInfo("en-US"),
             };
         }
@@ -64,6 +73,7 @@ namespace RunCat365
                 SupportedLanguage.French => "Consolas",
                 SupportedLanguage.German => "Consolas",
                 SupportedLanguage.SimplifiedChinese => "Microsoft YaHei",
+                SupportedLanguage.TraditionalChinese => "Microsoft JhengHei",
                 _ => "Consolas",
             };
         }
@@ -77,6 +87,7 @@ namespace RunCat365
                 SupportedLanguage.French => false,
                 SupportedLanguage.German => false,
                 SupportedLanguage.SimplifiedChinese => true,
+                SupportedLanguage.TraditionalChinese => true,
                 _ => false,
             };
         }

--- a/RunCat365/SupportedLanguage.cs
+++ b/RunCat365/SupportedLanguage.cs
@@ -18,48 +18,48 @@ namespace RunCat365
 {
     enum SupportedLanguage
     {
+        ChineseSimplified,
+        ChineseTraditional,
         English,
-        Japanese,
-        Spanish,
         French,
         German,
-        SimplifiedChinese,
-        TraditionalChinese,
+        Japanese,
+        Spanish,
     }
 
     internal static class SupportedLanguageExtension
     {
+        private static SupportedLanguage DetectChineseVariant(CultureInfo culture)
+        {
+            return culture.Name.Contains("Hant") || culture.Name is "zh-TW" or "zh-HK" or "zh-MO"
+                ? SupportedLanguage.ChineseTraditional
+                : SupportedLanguage.ChineseSimplified;
+        }
+
         internal static SupportedLanguage GetCurrentLanguage()
         {
             var culture = CultureInfo.CurrentUICulture;
             return culture.TwoLetterISOLanguageName switch
             {
-                "ja" => SupportedLanguage.Japanese,
-                "es" => SupportedLanguage.Spanish,
+                "zh" => DetectChineseVariant(culture),
                 "fr" => SupportedLanguage.French,
                 "de" => SupportedLanguage.German,
-                "zh" => DetectChineseVariant(culture),
+                "ja" => SupportedLanguage.Japanese,
+                "es" => SupportedLanguage.Spanish,
                 _ => SupportedLanguage.English,
             };
-        }
-
-        private static SupportedLanguage DetectChineseVariant(CultureInfo culture)
-        {
-            return culture.Name.Contains("Hant") || culture.Name is "zh-TW" or "zh-HK" or "zh-MO"
-                ? SupportedLanguage.TraditionalChinese
-                : SupportedLanguage.SimplifiedChinese;
         }
 
         internal static CultureInfo GetDefaultCultureInfo(this SupportedLanguage language)
         {
             return language switch
             {
-                SupportedLanguage.Japanese => new CultureInfo("ja-JP"),
-                SupportedLanguage.Spanish => new CultureInfo("es-ES"),
+                SupportedLanguage.ChineseSimplified => new CultureInfo("zh-CN"),
+                SupportedLanguage.ChineseTraditional => new CultureInfo("zh-TW"),
                 SupportedLanguage.French => new CultureInfo("fr-FR"),
                 SupportedLanguage.German => new CultureInfo("de-DE"),
-                SupportedLanguage.SimplifiedChinese => new CultureInfo("zh-CN"),
-                SupportedLanguage.TraditionalChinese => new CultureInfo("zh-TW"),
+                SupportedLanguage.Japanese => new CultureInfo("ja-JP"),
+                SupportedLanguage.Spanish => new CultureInfo("es-ES"),
                 _ => new CultureInfo("en-US"),
             };
         }
@@ -68,12 +68,12 @@ namespace RunCat365
         {
             return language switch
             {
-                SupportedLanguage.Japanese => "Noto Sans JP",
-                SupportedLanguage.Spanish => "Consolas",
+                SupportedLanguage.ChineseSimplified => "Microsoft YaHei",
+                SupportedLanguage.ChineseTraditional => "Microsoft JhengHei",
                 SupportedLanguage.French => "Consolas",
                 SupportedLanguage.German => "Consolas",
-                SupportedLanguage.SimplifiedChinese => "Microsoft YaHei",
-                SupportedLanguage.TraditionalChinese => "Microsoft JhengHei",
+                SupportedLanguage.Japanese => "Noto Sans JP",
+                SupportedLanguage.Spanish => "Consolas",
                 _ => "Consolas",
             };
         }
@@ -82,12 +82,12 @@ namespace RunCat365
         {
             return language switch
             {
-                SupportedLanguage.Japanese => true,
-                SupportedLanguage.Spanish => false,
+                SupportedLanguage.ChineseSimplified => true,
+                SupportedLanguage.ChineseTraditional => true,
                 SupportedLanguage.French => false,
                 SupportedLanguage.German => false,
-                SupportedLanguage.SimplifiedChinese => true,
-                SupportedLanguage.TraditionalChinese => true,
+                SupportedLanguage.Japanese => true,
+                SupportedLanguage.Spanish => false,
                 _ => false,
             };
         }


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

Adds Traditional Chinese (zh-TW) localization support, including a new `Strings.zh-TW.resx` resource file and detection logic to distinguish Traditional Chinese (zh-TW, zh-HK, zh-MO, zh-Hant-*) from Simplified Chinese (zh-CN).

## Reason for the new feature

The previously merged Simplified Chinese support used `TwoLetterISOLanguageName == "zh"` for detection, which matched both Simplified and Traditional Chinese users. This PR separates the two by introducing `TraditionalChinese` alongside `SimplifiedChinese` in `SupportedLanguage`, and adds `Strings.zh-TW.resx` with Taiwan-standard translations (e.g. 記憶體, 網路, 使用者). This benefits Traditional Chinese users in Taiwan, Hong Kong, and Macao.

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the Microsoft Store.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.