### PR TITLE
Allow users to choose between Celsius and Fahrenheit.

### DIFF
--- a/RunCat365/ContextMenuManager.cs
+++ b/RunCat365/ContextMenuManager.cs
@@ -43,6 +43,8 @@ namespace RunCat365
             Func<SpeedSource, bool> isSpeedSourceAvailable,
             Func<FPSMaxLimit> getFPSMaxLimit,
             Action<FPSMaxLimit> setFPSMaxLimit,
+            Func<TemperatureUnit> getTemperatureUnit,
+            Action<TemperatureUnit> setTemperatureUnit,
             Func<bool> getLaunchAtStartup,
             Func<bool, bool> toggleLaunchAtStartup,
             Action openProjectPage,
@@ -127,6 +129,22 @@ namespace RunCat365
                 _ => null
             );
 
+            var temperatureUnitMenu = new CustomToolStripMenuItem(Strings.Menu_TemperatureUnit);
+            temperatureUnitMenu.SetupSubMenusFromEnum<TemperatureUnit>(
+                u => u.GetLocalizedString(),
+                (parent, sender, e) =>
+                {
+                    HandleMenuItemSelection<TemperatureUnit>(
+                        parent,
+                        sender,
+                        (string? s, out TemperatureUnit u) => Enum.TryParse(s, out u),
+                        u => setTemperatureUnit(u)
+                    );
+                },
+                u => getTemperatureUnit() == u,
+                _ => null
+            );
+
             var launchAtStartupMenu = new CustomToolStripMenuItem(Strings.Menu_LaunchAtStartup)
             {
                 Checked = getLaunchAtStartup()
@@ -138,6 +156,7 @@ namespace RunCat365
                 themeMenu,
                 speedSourceMenu,
                 fpsMaxLimitMenu,
+                temperatureUnitMenu,
                 launchAtStartupMenu
             );
 

--- a/RunCat365/Program.cs
+++ b/RunCat365/Program.cs
@@ -67,6 +67,7 @@ namespace RunCat365
         private readonly FormsTimer animateTimer;
         private Runner runner = Runner.Cat;
         private Theme manualTheme = Theme.System;
+        private TemperatureUnit temperatureUnit = TemperatureUnit.System;
         private FPSMaxLimit fpsMaxLimit = FPSMaxLimit.FPS40;
         private SpeedSource speedSource = SpeedSource.CPU;
         private string? customRunnerName;
@@ -78,6 +79,7 @@ namespace RunCat365
             UserSettings.Default.Reload();
             _ = Enum.TryParse(UserSettings.Default.Runner, out runner);
             _ = Enum.TryParse(UserSettings.Default.Theme, out manualTheme);
+            _ = Enum.TryParse(UserSettings.Default.TemperatureUnit, out temperatureUnit);
             _ = Enum.TryParse(UserSettings.Default.FPSMaxLimit, out fpsMaxLimit);
             _ = Enum.TryParse(UserSettings.Default.SpeedSource, out speedSource);
             customRunnerName = string.IsNullOrEmpty(UserSettings.Default.CustomRunnerName)
@@ -112,6 +114,8 @@ namespace RunCat365
                 s => IsSpeedSourceAvailable(s),
                 () => fpsMaxLimit,
                 f => ChangeFPSMaxLimit(f),
+                () => temperatureUnit,
+                u => ChangeTemperatureUnit(u),
                 () => launchAtStartupManager.GetStartup(),
                 s => launchAtStartupManager.ToggleStartup(s),
                 () => OpenProjectPage(),
@@ -254,6 +258,13 @@ namespace RunCat365
             UserSettings.Default.Save();
         }
 
+        private void ChangeTemperatureUnit(TemperatureUnit u)
+        {
+            temperatureUnit = u;
+            UserSettings.Default.TemperatureUnit = temperatureUnit.ToString();
+            UserSettings.Default.Save();
+        }
+
         private void ChangeSpeedSource(SpeedSource s)
         {
             speedSource = s;
@@ -283,7 +294,7 @@ namespace RunCat365
                 _ => "",
             };
 
-            var temperatureDescription = temperatureInfo?.GetDescription(TemperatureUnit.System) ?? "";
+            var temperatureDescription = temperatureInfo?.GetDescription(temperatureUnit) ?? "";
             return string.IsNullOrEmpty(temperatureDescription) ? baseDescription : $"{baseDescription}\n{temperatureDescription}";
         }
 
@@ -320,7 +331,7 @@ namespace RunCat365
             systemInfoValues.AddRange(memoryInfo.GenerateIndicator());
             if (temperatureInfo.HasValue)
             {
-                systemInfoValues.AddRange(temperatureInfo.Value.GenerateIndicator(TemperatureUnit.System));
+                systemInfoValues.AddRange(temperatureInfo.Value.GenerateIndicator(temperatureUnit));
             }
             systemInfoValues.AddRange(storageInfo.GenerateIndicator());
             if (networkInfo.HasValue)

--- a/RunCat365/Program.cs
+++ b/RunCat365/Program.cs
@@ -283,7 +283,7 @@ namespace RunCat365
                 _ => "",
             };
 
-            var temperatureDescription = temperatureInfo?.GetDescription() ?? "";
+            var temperatureDescription = temperatureInfo?.GetDescription(TemperatureUnit.System) ?? "";
             return string.IsNullOrEmpty(temperatureDescription) ? baseDescription : $"{baseDescription}\n{temperatureDescription}";
         }
 
@@ -320,7 +320,7 @@ namespace RunCat365
             systemInfoValues.AddRange(memoryInfo.GenerateIndicator());
             if (temperatureInfo.HasValue)
             {
-                systemInfoValues.AddRange(temperatureInfo.Value.GenerateIndicator());
+                systemInfoValues.AddRange(temperatureInfo.Value.GenerateIndicator(TemperatureUnit.System));
             }
             systemInfoValues.AddRange(storageInfo.GenerateIndicator());
             if (networkInfo.HasValue)

--- a/RunCat365/Properties/Strings.Designer.cs
+++ b/RunCat365/Properties/Strings.Designer.cs
@@ -503,5 +503,29 @@ namespace RunCat365.Properties {
                 return ResourceManager.GetString("CustomRunner_PreviewSpeed", resourceCulture);
             }
         }
+
+        internal static string Menu_TemperatureUnit {
+            get {
+                return ResourceManager.GetString("Menu_TemperatureUnit", resourceCulture);
+            }
+        }
+
+        internal static string TemperatureUnit_System {
+            get {
+                return ResourceManager.GetString("TemperatureUnit_System", resourceCulture);
+            }
+        }
+
+        internal static string TemperatureUnit_Celsius {
+            get {
+                return ResourceManager.GetString("TemperatureUnit_Celsius", resourceCulture);
+            }
+        }
+
+        internal static string TemperatureUnit_Fahrenheit {
+            get {
+                return ResourceManager.GetString("TemperatureUnit_Fahrenheit", resourceCulture);
+            }
+        }
     }
 }

--- a/RunCat365/Properties/Strings.de.resx
+++ b/RunCat365/Properties/Strings.de.resx
@@ -153,6 +153,18 @@
   <data name="Theme_Dark" xml:space="preserve">
     <value>Dunkel</value>
   </data>
+  <data name="Menu_TemperatureUnit" xml:space="preserve">
+    <value>Temperatureinheit</value>
+  </data>
+  <data name="TemperatureUnit_System" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="TemperatureUnit_Celsius" xml:space="preserve">
+    <value>Celsius</value>
+  </data>
+  <data name="TemperatureUnit_Fahrenheit" xml:space="preserve">
+    <value>Fahrenheit</value>
+  </data>
   <data name="Runner_Cat" xml:space="preserve">
     <value>Katze</value>
   </data>

--- a/RunCat365/Properties/Strings.es.resx
+++ b/RunCat365/Properties/Strings.es.resx
@@ -153,6 +153,18 @@
   <data name="Theme_Dark" xml:space="preserve">
     <value>Oscuro</value>
   </data>
+  <data name="Menu_TemperatureUnit" xml:space="preserve">
+    <value>Unidad de temperatura</value>
+  </data>
+  <data name="TemperatureUnit_System" xml:space="preserve">
+    <value>Sistema</value>
+  </data>
+  <data name="TemperatureUnit_Celsius" xml:space="preserve">
+    <value>Celsius</value>
+  </data>
+  <data name="TemperatureUnit_Fahrenheit" xml:space="preserve">
+    <value>Fahrenheit</value>
+  </data>
   <data name="Runner_Cat" xml:space="preserve">
     <value>Gato</value>
   </data>

--- a/RunCat365/Properties/Strings.fr.resx
+++ b/RunCat365/Properties/Strings.fr.resx
@@ -153,6 +153,18 @@
   <data name="Theme_Dark" xml:space="preserve">
     <value>Sombre</value>
   </data>
+  <data name="Menu_TemperatureUnit" xml:space="preserve">
+    <value>Unité de température</value>
+  </data>
+  <data name="TemperatureUnit_System" xml:space="preserve">
+    <value>Système</value>
+  </data>
+  <data name="TemperatureUnit_Celsius" xml:space="preserve">
+    <value>Celsius</value>
+  </data>
+  <data name="TemperatureUnit_Fahrenheit" xml:space="preserve">
+    <value>Fahrenheit</value>
+  </data>
   <data name="Runner_Cat" xml:space="preserve">
     <value>Chat</value>
   </data>

--- a/RunCat365/Properties/Strings.ja.resx
+++ b/RunCat365/Properties/Strings.ja.resx
@@ -153,6 +153,18 @@
   <data name="Theme_Dark" xml:space="preserve">
     <value>ダーク</value>
   </data>
+  <data name="Menu_TemperatureUnit" xml:space="preserve">
+    <value>温度単位</value>
+  </data>
+  <data name="TemperatureUnit_System" xml:space="preserve">
+    <value>システム</value>
+  </data>
+  <data name="TemperatureUnit_Celsius" xml:space="preserve">
+    <value>摂氏</value>
+  </data>
+  <data name="TemperatureUnit_Fahrenheit" xml:space="preserve">
+    <value>華氏</value>
+  </data>
   <data name="Runner_Cat" xml:space="preserve">
     <value>ネコ</value>
   </data>

--- a/RunCat365/Properties/Strings.resx
+++ b/RunCat365/Properties/Strings.resx
@@ -153,6 +153,18 @@
   <data name="Theme_Dark" xml:space="preserve">
     <value>Dark</value>
   </data>
+  <data name="Menu_TemperatureUnit" xml:space="preserve">
+    <value>Temperature Unit</value>
+  </data>
+  <data name="TemperatureUnit_System" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="TemperatureUnit_Celsius" xml:space="preserve">
+    <value>Celsius</value>
+  </data>
+  <data name="TemperatureUnit_Fahrenheit" xml:space="preserve">
+    <value>Fahrenheit</value>
+  </data>
   <data name="Runner_Cat" xml:space="preserve">
     <value>Cat</value>
   </data>

--- a/RunCat365/Properties/Strings.zh-CN.resx
+++ b/RunCat365/Properties/Strings.zh-CN.resx
@@ -153,6 +153,18 @@
   <data name="Theme_Dark" xml:space="preserve">
     <value>深色</value>
   </data>
+  <data name="Menu_TemperatureUnit" xml:space="preserve">
+    <value>温度单位</value>
+  </data>
+  <data name="TemperatureUnit_System" xml:space="preserve">
+    <value>系统</value>
+  </data>
+  <data name="TemperatureUnit_Celsius" xml:space="preserve">
+    <value>摄氏</value>
+  </data>
+  <data name="TemperatureUnit_Fahrenheit" xml:space="preserve">
+    <value>华氏</value>
+  </data>
   <data name="Runner_Cat" xml:space="preserve">
     <value>猫咪</value>
   </data>

--- a/RunCat365/Properties/Strings.zh-TW.resx
+++ b/RunCat365/Properties/Strings.zh-TW.resx
@@ -153,6 +153,18 @@
   <data name="Theme_Dark" xml:space="preserve">
     <value>深色</value>
   </data>
+  <data name="Menu_TemperatureUnit" xml:space="preserve">
+    <value>溫度單位</value>
+  </data>
+  <data name="TemperatureUnit_System" xml:space="preserve">
+    <value>系統</value>
+  </data>
+  <data name="TemperatureUnit_Celsius" xml:space="preserve">
+    <value>攝氏</value>
+  </data>
+  <data name="TemperatureUnit_Fahrenheit" xml:space="preserve">
+    <value>華氏</value>
+  </data>
   <data name="Runner_Cat" xml:space="preserve">
     <value>貓咪</value>
   </data>

--- a/RunCat365/Properties/UserSettings.Designer.cs
+++ b/RunCat365/Properties/UserSettings.Designer.cs
@@ -46,7 +46,19 @@ namespace RunCat365.Properties {
                 this["Theme"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string TemperatureUnit {
+            get {
+                return ((string)(this["TemperatureUnit"]));
+            }
+            set {
+                this["TemperatureUnit"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("FPS40")]

--- a/RunCat365/Properties/UserSettings.settings
+++ b/RunCat365/Properties/UserSettings.settings
@@ -8,6 +8,9 @@
     <Setting Name="Theme" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="TemperatureUnit" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
     <Setting Name="FPSMaxLimit" Type="System.String" Scope="User">
       <Value Profile="(Default)">FPS40</Value>
     </Setting>

--- a/RunCat365/TemperatureRepository.cs
+++ b/RunCat365/TemperatureRepository.cs
@@ -29,43 +29,32 @@ namespace RunCat365
         private const float CELSIUS_TO_FAHRENHEIT_SCALE = 9.0f / 5.0f;
         private const float CELSIUS_TO_FAHRENHEIT_OFFSET = 32.0f;
 
-        private static readonly bool usesFahrenheit = UsesFahrenheit();
-
-        internal static string GetDescription(this TemperatureInfo temperatureInfo)
+        internal static string GetDescription(this TemperatureInfo temperatureInfo, TemperatureUnit unit)
         {
-            return $"{Strings.SystemInfo_Temperature}: {temperatureInfo.MaximumCelsius.ToLocalizedTemperatureText()}";
+            var resolvedUnit = unit.Resolve();
+            return $"{Strings.SystemInfo_Temperature}: {temperatureInfo.MaximumCelsius.ToLocalizedTemperatureText(resolvedUnit)}";
         }
 
-        internal static List<string> GenerateIndicator(this TemperatureInfo temperatureInfo)
+        internal static List<string> GenerateIndicator(this TemperatureInfo temperatureInfo, TemperatureUnit unit)
         {
+            var resolvedUnit = unit.Resolve();
             return [
                 TreeFormatter.CreateRoot($"{Strings.SystemInfo_Temperature}:"),
-                TreeFormatter.CreateNode($"{Strings.SystemInfo_Average}: {temperatureInfo.AverageCelsius.ToLocalizedTemperatureText()}", false),
-                TreeFormatter.CreateNode($"{Strings.SystemInfo_Maximum}: {temperatureInfo.MaximumCelsius.ToLocalizedTemperatureText()}", true)
+                TreeFormatter.CreateNode($"{Strings.SystemInfo_Average}: {temperatureInfo.AverageCelsius.ToLocalizedTemperatureText(resolvedUnit)}", false),
+                TreeFormatter.CreateNode($"{Strings.SystemInfo_Maximum}: {temperatureInfo.MaximumCelsius.ToLocalizedTemperatureText(resolvedUnit)}", true)
             ];
         }
 
-        private static string ToLocalizedTemperatureText(this float temperatureCelsius)
+        private static string ToLocalizedTemperatureText(this float temperatureCelsius, TemperatureUnit resolvedUnit)
         {
-            var value = usesFahrenheit
+            var useFahrenheit = resolvedUnit == TemperatureUnit.Fahrenheit;
+            var value = useFahrenheit
                 ? temperatureCelsius * CELSIUS_TO_FAHRENHEIT_SCALE + CELSIUS_TO_FAHRENHEIT_OFFSET
                 : temperatureCelsius;
-            var format = usesFahrenheit
+            var format = useFahrenheit
                 ? Strings.SystemInfo_TemperatureFahrenheitFormat
                 : Strings.SystemInfo_TemperatureCelsiusFormat;
             return string.Format(CultureInfo.CurrentCulture, format, value);
-        }
-
-        private static bool UsesFahrenheit()
-        {
-            try
-            {
-                return !new RegionInfo(CultureInfo.CurrentCulture.Name).IsMetric;
-            }
-            catch (ArgumentException)
-            {
-                return false;
-            }
         }
     }
 

--- a/RunCat365/TemperatureUnit.cs
+++ b/RunCat365/TemperatureUnit.cs
@@ -1,0 +1,72 @@
+// Copyright 2025 Takuto Nakamura
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using RunCat365.Properties;
+using System.Globalization;
+
+namespace RunCat365
+{
+    enum TemperatureUnit
+    {
+        System,
+        Celsius,
+        Fahrenheit,
+    }
+
+    internal static class TemperatureUnitExtension
+    {
+        private static readonly TemperatureUnit systemDefault = DetectSystemDefault();
+
+        internal static string GetString(this TemperatureUnit unit)
+        {
+            return unit switch
+            {
+                TemperatureUnit.System => "System",
+                TemperatureUnit.Celsius => "Celsius",
+                TemperatureUnit.Fahrenheit => "Fahrenheit",
+                _ => "",
+            };
+        }
+
+        internal static string GetLocalizedString(this TemperatureUnit unit)
+        {
+            return unit switch
+            {
+                TemperatureUnit.System => Strings.TemperatureUnit_System,
+                TemperatureUnit.Celsius => Strings.TemperatureUnit_Celsius,
+                TemperatureUnit.Fahrenheit => Strings.TemperatureUnit_Fahrenheit,
+                _ => "",
+            };
+        }
+
+        internal static TemperatureUnit Resolve(this TemperatureUnit unit)
+        {
+            return unit == TemperatureUnit.System ? systemDefault : unit;
+        }
+
+        private static TemperatureUnit DetectSystemDefault()
+        {
+            try
+            {
+                return new RegionInfo(CultureInfo.CurrentCulture.Name).IsMetric
+                    ? TemperatureUnit.Celsius
+                    : TemperatureUnit.Fahrenheit;
+            }
+            catch (ArgumentException)
+            {
+                return TemperatureUnit.Celsius;
+            }
+        }
+    }
+}

--- a/RunCat365/TemperatureUnit.cs
+++ b/RunCat365/TemperatureUnit.cs
@@ -28,17 +28,6 @@ namespace RunCat365
     {
         private static readonly TemperatureUnit systemDefault = DetectSystemDefault();
 
-        internal static string GetString(this TemperatureUnit unit)
-        {
-            return unit switch
-            {
-                TemperatureUnit.System => "System",
-                TemperatureUnit.Celsius => "Celsius",
-                TemperatureUnit.Fahrenheit => "Fahrenheit",
-                _ => "",
-            };
-        }
-
         internal static string GetLocalizedString(this TemperatureUnit unit)
         {
             return unit switch


### PR DESCRIPTION
## Context of Contribution

<!-- Each pull request should fix only one issue or propose one feature. -->
<!-- Do not mix unrelated changes in a single PR. -->

- [ ] Bug Fix
- [ ] Refactoring
- [x] New Feature
- [ ] Others

## Summary of the Proposal

By default, Celsius or Fahrenheit is automatically selected based on the language.
Users can manually specify Celsius or Fahrenheit in the user settings.

## Reason for the new feature

#310

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the Microsoft Store.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.
