### PR TITLE
Refresh CLAUDE.md for OSS contributors and current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,81 +9,44 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - If multiple requirements are given in a single instruction, divide the commits into appropriate sizes/granularities.
 - When creating a pull request, use the `.claude/skills/create-pr` skill so the project's `.github/pull_request_template.md` is followed.
 
-## Build & Development
+## Project Overview
 
-This is a Windows Forms application (.NET 9.0 / C#) for Microsoft Store distribution.
+Windows Forms application (.NET 9.0 / C#) distributed via the Microsoft Store. Runs as a system tray icon whose animation reflects system load.
 
-**Solution structure:**
+**Top-level layout:**
 
-- `RunCat365.sln` - Main solution file
-- `RunCat365/` - Main application project
-- `WapForStore/` - Windows Application Packaging project for Microsoft Store
+- `RunCat365.sln` — Main solution
+- `RunCat365/` — Main application project
+- `WapForStore/` — Windows Application Packaging project for the Microsoft Store
 
-**Build:**
+**Build:** Open `RunCat365.sln` in Visual Studio. Supported platforms: x64, x86, ARM64. Target framework: .NET 9.0 (Windows 10.0.26100.0).
 
-- Open `RunCat365.sln` in Visual Studio
-- Supported platforms: x64, x86, ARM64
-- Target framework: .NET 9.0 (Windows 10.0.26100.0)
+**Releasing — version numbers must be updated in two places:**
 
-**Version numbers** must be updated in two places when releasing:
+1. `RunCat365/RunCat365.csproj` — `<Version>X.Y.Z</Version>` (3-digit)
+2. `WapForStore/Package.appxmanifest` — `Version="X.Y.Z.0"` in `<Identity>` (4-digit)
 
-1. `RunCat365/RunCat365.csproj` - `<Version>X.Y.Z</Version>` (3-digit)
-2. `WapForStore/Package.appxmanifest` - `Version="X.Y.Z.0"` in `<Identity>` element (4-digit)
+## Architecture (patterns, not file lists)
 
-## Architecture
+- **Entry point:** `Program.cs` hosts the tray application context that owns the timers, the tray icon, and the context menu.
+- **Repository pattern for system metrics:** Each metric has a `*Repository` class that produces a matching `*Info` struct (CPU / GPU / memory / storage / network / temperature). Add a new metric by adding a paired repository and info struct.
+- **Animation loop:** A 1-second fetch timer refreshes the `*Info` structs; a separate animate timer advances frames at a rate derived from the `SpeedSource` setting. Theme-aware icon recoloring lives in `BitmapExtension`.
+- **Custom runners:** User-defined animations are loaded from `profiles.json` and managed by the `CustomRunner*` classes; the active profile is stored in the `CustomRunnerName` setting.
+- **EndlessGame:** Mini-game living in `EndlessGameForm` and its collaborator classes.
+- **Settings & resources:** Persisted user preferences in `Properties/UserSettings.settings`; embedded images/icons in `Properties/Resources.resx`.
 
-**Entry point:** `Program.cs` contains `RunCat365ApplicationContext` which manages the application lifecycle as a system tray application.
+## Localization
 
-**Core components:**
-
-- `ContextMenuManager` - Manages the system tray icon, context menu, and notification icon animation; uses `iconLock` for thread-safe icon updates
-- `Runner` - Enum for built-in animation types (Cat, Parrot, Horse) with frame counts
-- `CustomRunnerForm` / `CustomRunnerProfile` / `CustomRunnerRepository` - User-defined runner animations loaded from `profiles.json` (selected via the `CustomRunnerName` setting)
-- `EndlessGameForm` - Mini-game featuring the running cat
-- `LaunchAtStartupManager` - Startup registration via Windows App Runtime
-
-**System information repositories (Repository pattern):**
-
-- `CPURepository` - CPU usage via PerformanceCounter
-- `GPURepository` - GPU usage monitoring
-- `MemoryRepository` - Memory usage
-- `StorageRepository` - Disk usage
-- `NetworkRepository` - Network statistics
-- `TemperatureRepository` - CPU temperature (Celsius / Fahrenheit selectable via `TemperatureUnit` setting)
-
-**Animation flow:**
-
-1. `fetchTimer` (1s interval) updates system info into `*Info` structs (CPUInfo, GPUInfo, etc.)
-2. `animateTimer` advances frames based on the selected `SpeedSource` (CPU/GPU/Memory)
-3. `BitmapExtension` handles theme-aware icon recoloring and conversion
-
-**EndlessGame components:**
-
-- `Cat` - Running/Jumping state and collision frame data
-- `Road` - Obstacle types (Flat/Hill/Crater/Sprout)
-- `GameStatus` - Game state (NewGame/Playing/GameOver)
-
-**Utilities:**
-
-- `ByteFormatter` - Formats byte values to human-readable strings (B/KB/MB/GB/TB)
-- `TreeFormatter` - Formats system info for context menu display (language-aware)
-
-**Settings:**
-
-- `Properties/UserSettings.settings` - User preferences (Runner, Theme, TemperatureUnit, FPSMaxLimit, FirstLaunch, HighScore, SpeedSource, CustomRunnerName)
-- `Properties/Resources.resx` - Embedded images and icons
-- `Properties/Strings.resx` - Localized strings (English default); per-locale variants live alongside as `Properties/Strings.{locale}.resx`
-
-**Localization notes:**
-
-- Add new strings to every `Strings*.resx` file simultaneously
-- Per-locale font and culture settings live in `SupportedLanguage.cs` (`GetFontName`, `GetDefaultCultureInfo`, `IsFullWidth`)
-- When adding a brand-new locale (not just new strings), follow the `.claude/skills/add-locale` skill
+- Localized strings live in `Properties/Strings.resx` (English default) and sibling `Properties/Strings.{locale}.resx` files. Any new string must be added to every variant.
+- Per-locale font and culture settings live in `SupportedLanguage.cs`.
+- When adding a brand-new locale (not just new strings), follow the `.claude/skills/add-locale` skill.
 
 ## Coding Rules
 
-- Do not write comments within the source code.
-- Use naming conventions that clearly indicate the purpose of the code, even without comments.
-- In C# code:
-  - Abbreviations such as URL or ID should be written in all lowercase or all uppercase (do not use Upper Camel Case for these prefixes).
-  - Do not use abbreviations such as `img` for `image` or `cnt` for `count`.
+General contribution rules — indentation style, `var` usage, single-change PRs, English-only code, license, and the rest — are documented in [`CONTRIBUTING.md`](CONTRIBUTING.md). Follow those first.
+
+Project-specific additions:
+
+- Do not write comments within the source code. Use names that make intent obvious.
+- Write abbreviations such as URL or ID in either all lowercase or all uppercase (do not use Upper Camel Case for them).
+- Do not use abbreviations like `img` for `image` or `cnt` for `count`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## You Must
 
-- Please respond in Japanese.
+- Respond in the same language the user is writing in.
 - Commit to Git only when instructed.
 - If multiple requirements are given in a single instruction, divide the commits into appropriate sizes/granularities.
+- When creating a pull request, use the `.claude/skills/create-pr` skill so the project's `.github/pull_request_template.md` is followed.
 
 ## Build & Development
 
@@ -36,7 +37,8 @@ This is a Windows Forms application (.NET 9.0 / C#) for Microsoft Store distribu
 **Core components:**
 
 - `ContextMenuManager` - Manages the system tray icon, context menu, and notification icon animation; uses `iconLock` for thread-safe icon updates
-- `Runner` - Enum for animation types (Cat, Parrot, Horse) with frame counts
+- `Runner` - Enum for built-in animation types (Cat, Parrot, Horse) with frame counts
+- `CustomRunnerForm` / `CustomRunnerProfile` / `CustomRunnerRepository` - User-defined runner animations loaded from `profiles.json` (selected via the `CustomRunnerName` setting)
 - `EndlessGameForm` - Mini-game featuring the running cat
 - `LaunchAtStartupManager` - Startup registration via Windows App Runtime
 
@@ -47,6 +49,7 @@ This is a Windows Forms application (.NET 9.0 / C#) for Microsoft Store distribu
 - `MemoryRepository` - Memory usage
 - `StorageRepository` - Disk usage
 - `NetworkRepository` - Network statistics
+- `TemperatureRepository` - CPU temperature (Celsius / Fahrenheit selectable via `TemperatureUnit` setting)
 
 **Animation flow:**
 
@@ -67,7 +70,7 @@ This is a Windows Forms application (.NET 9.0 / C#) for Microsoft Store distribu
 
 **Settings:**
 
-- `Properties/UserSettings.settings` - User preferences (Runner, Theme, SpeedSource, FPSMaxLimit)
+- `Properties/UserSettings.settings` - User preferences (Runner, Theme, TemperatureUnit, FPSMaxLimit, FirstLaunch, HighScore, SpeedSource, CustomRunnerName)
 - `Properties/Resources.resx` - Embedded images and icons
 - `Properties/Strings.resx` - Localized strings (English default); per-locale variants live alongside as `Properties/Strings.{locale}.resx`
 


### PR DESCRIPTION
## Context of Contribution

- [ ] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [x] Others

## Summary of the Proposal

Documentation-only update to `CLAUDE.md`. Drops the Japanese-only response rule so OSS contributors writing in any language are answered in their language, points at the `create-pr` skill so the project's PR template is followed, and brings the architecture description in sync with the code (adds Custom Runner components and `TemperatureRepository`, refreshes the `UserSettings` list).

## Reason for the new feature

N/A

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the Microsoft Store.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.