### PR TITLE
Improve performance counter accuracy and resilience

### DIFF
--- a/RunCat365/CPURepository.cs
+++ b/RunCat365/CPURepository.cs
@@ -47,31 +47,66 @@ namespace RunCat365
 
     internal class CPUPerformanceCounters
     {
+        private const string PROCESSOR_INFORMATION_CATEGORY = "Processor Information";
+        private const string PROCESSOR_CATEGORY = "Processor";
+        private const string TOTAL_INSTANCE = "_Total";
+
         internal PerformanceCounter Total { get; }
         internal PerformanceCounter User { get; }
         internal PerformanceCounter Kernel { get; }
         internal PerformanceCounter Idle { get; }
 
-        private CPUPerformanceCounters()
+        private CPUPerformanceCounters(
+            PerformanceCounter total,
+            PerformanceCounter user,
+            PerformanceCounter kernel,
+            PerformanceCounter idle)
         {
-            Total = new PerformanceCounter("Processor", "% Processor Time", "_Total");
-            User = new PerformanceCounter("Processor", "% User Time", "_Total");
-            Kernel = new PerformanceCounter("Processor", "% Privileged Time", "_Total");
-            Idle = new PerformanceCounter("Processor", "% Idle Time", "_Total");
-            _ = Total.NextValue();
-            _ = User.NextValue();
-            _ = Kernel.NextValue();
-            _ = Idle.NextValue();
+            Total = total;
+            User = user;
+            Kernel = kernel;
+            Idle = idle;
         }
 
         internal static CPUPerformanceCounters? TryCreate()
         {
+            return TryCreateFromCategory(PROCESSOR_INFORMATION_CATEGORY, TOTAL_INSTANCE)
+                ?? TryCreateFromCategory(PROCESSOR_CATEGORY, TOTAL_INSTANCE);
+        }
+
+        private static CPUPerformanceCounters? TryCreateFromCategory(string categoryName, string instanceName)
+        {
+            PerformanceCounter? total = null;
+            PerformanceCounter? user = null;
+            PerformanceCounter? kernel = null;
+            PerformanceCounter? idle = null;
             try
             {
-                return new CPUPerformanceCounters();
+                total = new PerformanceCounter(categoryName, "% Processor Utility", instanceName);
             }
             catch
             {
+                total?.Close();
+                total = null;
+            }
+            try
+            {
+                total ??= new PerformanceCounter(categoryName, "% Processor Time", instanceName);
+                user = new PerformanceCounter(categoryName, "% User Time", instanceName);
+                kernel = new PerformanceCounter(categoryName, "% Privileged Time", instanceName);
+                idle = new PerformanceCounter(categoryName, "% Idle Time", instanceName);
+                _ = total.NextValue();
+                _ = user.NextValue();
+                _ = kernel.NextValue();
+                _ = idle.NextValue();
+                return new CPUPerformanceCounters(total, user, kernel, idle);
+            }
+            catch
+            {
+                total?.Close();
+                user?.Close();
+                kernel?.Close();
+                idle?.Close();
                 return null;
             }
         }

--- a/RunCat365/CPURepository.cs
+++ b/RunCat365/CPURepository.cs
@@ -50,6 +50,11 @@ namespace RunCat365
         private const string PROCESSOR_INFORMATION_CATEGORY = "Processor Information";
         private const string PROCESSOR_CATEGORY = "Processor";
         private const string TOTAL_INSTANCE = "_Total";
+        private const string PROCESSOR_UTILITY_COUNTER = "% Processor Utility";
+        private const string PROCESSOR_TIME_COUNTER = "% Processor Time";
+        private const string USER_TIME_COUNTER = "% User Time";
+        private const string PRIVILEGED_TIME_COUNTER = "% Privileged Time";
+        private const int PROCESSOR_TIME_BASED_TASK_MANAGER_MINIMUM_BUILD = 26100;
 
         internal PerformanceCounter Total { get; }
         internal PerformanceCounter User { get; }
@@ -71,25 +76,33 @@ namespace RunCat365
                 ?? TryCreateFromCategory(PROCESSOR_CATEGORY, TOTAL_INSTANCE);
         }
 
+        private static bool TaskManagerUsesProcessorTime()
+        {
+            return PROCESSOR_TIME_BASED_TASK_MANAGER_MINIMUM_BUILD <= Environment.OSVersion.Version.Build;
+        }
+
         private static CPUPerformanceCounters? TryCreateFromCategory(string categoryName, string instanceName)
         {
             PerformanceCounter? total = null;
             PerformanceCounter? user = null;
             PerformanceCounter? kernel = null;
+            if (!TaskManagerUsesProcessorTime())
+            {
+                try
+                {
+                    total = new PerformanceCounter(categoryName, PROCESSOR_UTILITY_COUNTER, instanceName);
+                }
+                catch
+                {
+                    total?.Close();
+                    total = null;
+                }
+            }
             try
             {
-                total = new PerformanceCounter(categoryName, "% Processor Utility", instanceName);
-            }
-            catch
-            {
-                total?.Close();
-                total = null;
-            }
-            try
-            {
-                total ??= new PerformanceCounter(categoryName, "% Processor Time", instanceName);
-                user = new PerformanceCounter(categoryName, "% User Time", instanceName);
-                kernel = new PerformanceCounter(categoryName, "% Privileged Time", instanceName);
+                total ??= new PerformanceCounter(categoryName, PROCESSOR_TIME_COUNTER, instanceName);
+                user = new PerformanceCounter(categoryName, USER_TIME_COUNTER, instanceName);
+                kernel = new PerformanceCounter(categoryName, PRIVILEGED_TIME_COUNTER, instanceName);
                 _ = total.NextValue();
                 _ = user.NextValue();
                 _ = kernel.NextValue();

--- a/RunCat365/CPURepository.cs
+++ b/RunCat365/CPURepository.cs
@@ -54,18 +54,15 @@ namespace RunCat365
         internal PerformanceCounter Total { get; }
         internal PerformanceCounter User { get; }
         internal PerformanceCounter Kernel { get; }
-        internal PerformanceCounter Idle { get; }
 
         private CPUPerformanceCounters(
             PerformanceCounter total,
             PerformanceCounter user,
-            PerformanceCounter kernel,
-            PerformanceCounter idle)
+            PerformanceCounter kernel)
         {
             Total = total;
             User = user;
             Kernel = kernel;
-            Idle = idle;
         }
 
         internal static CPUPerformanceCounters? TryCreate()
@@ -79,7 +76,6 @@ namespace RunCat365
             PerformanceCounter? total = null;
             PerformanceCounter? user = null;
             PerformanceCounter? kernel = null;
-            PerformanceCounter? idle = null;
             try
             {
                 total = new PerformanceCounter(categoryName, "% Processor Utility", instanceName);
@@ -94,19 +90,16 @@ namespace RunCat365
                 total ??= new PerformanceCounter(categoryName, "% Processor Time", instanceName);
                 user = new PerformanceCounter(categoryName, "% User Time", instanceName);
                 kernel = new PerformanceCounter(categoryName, "% Privileged Time", instanceName);
-                idle = new PerformanceCounter(categoryName, "% Idle Time", instanceName);
                 _ = total.NextValue();
                 _ = user.NextValue();
                 _ = kernel.NextValue();
-                _ = idle.NextValue();
-                return new CPUPerformanceCounters(total, user, kernel, idle);
+                return new CPUPerformanceCounters(total, user, kernel);
             }
             catch
             {
                 total?.Close();
                 user?.Close();
                 kernel?.Close();
-                idle?.Close();
                 return null;
             }
         }
@@ -116,7 +109,6 @@ namespace RunCat365
             Total.Close();
             User.Close();
             Kernel.Close();
-            Idle.Close();
         }
     }
 
@@ -137,12 +129,17 @@ namespace RunCat365
         {
             if (counters is null) return;
 
+            var total = Math.Min(100, counters.Total.NextValue());
+            var user = Math.Min(100, counters.User.NextValue());
+            var kernel = Math.Min(100, counters.Kernel.NextValue());
+            var idle = Math.Max(0, 100 - user - kernel);
+
             var cpuInfo = new CPUInfo
             {
-                Total = Math.Min(100, counters.Total.NextValue()),
-                User = Math.Min(100, counters.User.NextValue()),
-                Kernel = Math.Min(100, counters.Kernel.NextValue()),
-                Idle = Math.Min(100, counters.Idle.NextValue()),
+                Total = total,
+                User = user,
+                Kernel = kernel,
+                Idle = idle,
             };
 
             cpuInfoList.Add(cpuInfo);

--- a/RunCat365/GPURepository.cs
+++ b/RunCat365/GPURepository.cs
@@ -13,7 +13,6 @@
 //    limitations under the License.
 
 using RunCat365.Properties;
-using System.Diagnostics;
 
 namespace RunCat365
 {
@@ -42,113 +41,22 @@ namespace RunCat365
         }
     }
 
-    internal class GPUPerformanceCounters
+    internal sealed class GPUPerformanceCounters : InstancedPerformanceCounters
     {
-        private const string CATEGORY_NAME = "GPU Engine";
-        private const string COUNTER_NAME = "Utilization Percentage";
         private const string ENGINE_TYPE_FILTER = "engtype_3D";
 
-        private readonly Dictionary<string, PerformanceCounter> countersByInstance = [];
+        protected override string CategoryName => "GPU Engine";
+        protected override string CounterName => "Utilization Percentage";
 
-        private GPUPerformanceCounters() { }
-
-        internal int Count => countersByInstance.Count;
+        protected override bool ShouldIncludeInstance(string instanceName)
+        {
+            return instanceName.Contains(ENGINE_TYPE_FILTER);
+        }
 
         internal static GPUPerformanceCounters? TryCreate()
         {
-            try
-            {
-                _ = new PerformanceCounterCategory(CATEGORY_NAME);
-            }
-            catch
-            {
-                return null;
-            }
-
             var instance = new GPUPerformanceCounters();
-            instance.RefreshInstances();
-            return instance.Count == 0 ? null : instance;
-        }
-
-        internal void RefreshInstances()
-        {
-            string[] currentInstanceNames;
-            try
-            {
-                var category = new PerformanceCounterCategory(CATEGORY_NAME);
-                currentInstanceNames = category.GetInstanceNames()
-                    .Where(name => name.Contains(ENGINE_TYPE_FILTER))
-                    .ToArray();
-            }
-            catch (Exception exception) when (
-                exception is InvalidOperationException
-                or System.ComponentModel.Win32Exception
-                or UnauthorizedAccessException)
-            {
-                Debug.WriteLine($"GPUPerformanceCounters.RefreshInstances failed: {exception.Message}");
-                return;
-            }
-
-            var currentSet = new HashSet<string>(currentInstanceNames, StringComparer.Ordinal);
-            var staleInstances = countersByInstance.Keys
-                .Where(name => !currentSet.Contains(name))
-                .ToList();
-            foreach (var instanceName in staleInstances)
-            {
-                countersByInstance[instanceName].Close();
-                countersByInstance.Remove(instanceName);
-            }
-
-            foreach (var instanceName in currentInstanceNames)
-            {
-                if (countersByInstance.ContainsKey(instanceName)) continue;
-                try
-                {
-                    var counter = new PerformanceCounter(CATEGORY_NAME, COUNTER_NAME, instanceName);
-                    _ = counter.NextValue();
-                    countersByInstance[instanceName] = counter;
-                }
-                catch (Exception exception) when (
-                    exception is InvalidOperationException
-                    or System.ComponentModel.Win32Exception
-                    or UnauthorizedAccessException)
-                {
-                    Debug.WriteLine($"GPUPerformanceCounters: failed to create counter for {instanceName}: {exception.Message}");
-                }
-            }
-        }
-
-        internal List<float> ReadValues()
-        {
-            var values = new List<float>(countersByInstance.Count);
-            var deadInstances = new List<string>();
-            foreach (var pair in countersByInstance)
-            {
-                try
-                {
-                    values.Add(pair.Value.NextValue());
-                }
-                catch (Exception exception) when (
-                    exception is InvalidOperationException
-                    or System.ComponentModel.Win32Exception
-                    or UnauthorizedAccessException)
-                {
-                    Debug.WriteLine($"GPUPerformanceCounters: counter {pair.Key} failed: {exception.Message}");
-                    deadInstances.Add(pair.Key);
-                }
-            }
-            foreach (var instanceName in deadInstances)
-            {
-                countersByInstance[instanceName].Close();
-                countersByInstance.Remove(instanceName);
-            }
-            return values;
-        }
-
-        internal void Close()
-        {
-            foreach (var counter in countersByInstance.Values) counter.Close();
-            countersByInstance.Clear();
+            return instance.TryInitialize() ? instance : null;
         }
     }
 

--- a/RunCat365/GPURepository.cs
+++ b/RunCat365/GPURepository.cs
@@ -48,51 +48,118 @@ namespace RunCat365
         private const string COUNTER_NAME = "Utilization Percentage";
         private const string ENGINE_TYPE_FILTER = "engtype_3D";
 
-        internal IReadOnlyList<PerformanceCounter> Counters { get; }
+        private readonly Dictionary<string, PerformanceCounter> countersByInstance = [];
 
-        private GPUPerformanceCounters(List<PerformanceCounter> counters)
-        {
-            Counters = counters;
-        }
+        private GPUPerformanceCounters() { }
+
+        internal int Count => countersByInstance.Count;
 
         internal static GPUPerformanceCounters? TryCreate()
         {
-            var counters = new List<PerformanceCounter>();
             try
             {
-                var category = new PerformanceCounterCategory(CATEGORY_NAME);
-                var instances = category.GetInstanceNames()
-                    .Where(n => n.Contains(ENGINE_TYPE_FILTER))
-                    .ToList();
-                if (instances.Count == 0) return null;
-
-                foreach (var instance in instances)
-                {
-                    var counter = new PerformanceCounter(CATEGORY_NAME, COUNTER_NAME, instance);
-                    counters.Add(counter);
-                    _ = counter.NextValue();
-                }
-                return new GPUPerformanceCounters(counters);
+                _ = new PerformanceCounterCategory(CATEGORY_NAME);
             }
             catch
             {
-                foreach (var counter in counters) counter.Close();
                 return null;
             }
+
+            var instance = new GPUPerformanceCounters();
+            instance.RefreshInstances();
+            return instance.Count == 0 ? null : instance;
+        }
+
+        internal void RefreshInstances()
+        {
+            string[] currentInstanceNames;
+            try
+            {
+                var category = new PerformanceCounterCategory(CATEGORY_NAME);
+                currentInstanceNames = category.GetInstanceNames()
+                    .Where(name => name.Contains(ENGINE_TYPE_FILTER))
+                    .ToArray();
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or System.ComponentModel.Win32Exception
+                or UnauthorizedAccessException)
+            {
+                Debug.WriteLine($"GPUPerformanceCounters.RefreshInstances failed: {exception.Message}");
+                return;
+            }
+
+            var currentSet = new HashSet<string>(currentInstanceNames, StringComparer.Ordinal);
+            var staleInstances = countersByInstance.Keys
+                .Where(name => !currentSet.Contains(name))
+                .ToList();
+            foreach (var instanceName in staleInstances)
+            {
+                countersByInstance[instanceName].Close();
+                countersByInstance.Remove(instanceName);
+            }
+
+            foreach (var instanceName in currentInstanceNames)
+            {
+                if (countersByInstance.ContainsKey(instanceName)) continue;
+                try
+                {
+                    var counter = new PerformanceCounter(CATEGORY_NAME, COUNTER_NAME, instanceName);
+                    _ = counter.NextValue();
+                    countersByInstance[instanceName] = counter;
+                }
+                catch (Exception exception) when (
+                    exception is InvalidOperationException
+                    or System.ComponentModel.Win32Exception
+                    or UnauthorizedAccessException)
+                {
+                    Debug.WriteLine($"GPUPerformanceCounters: failed to create counter for {instanceName}: {exception.Message}");
+                }
+            }
+        }
+
+        internal List<float> ReadValues()
+        {
+            var values = new List<float>(countersByInstance.Count);
+            var deadInstances = new List<string>();
+            foreach (var pair in countersByInstance)
+            {
+                try
+                {
+                    values.Add(pair.Value.NextValue());
+                }
+                catch (Exception exception) when (
+                    exception is InvalidOperationException
+                    or System.ComponentModel.Win32Exception
+                    or UnauthorizedAccessException)
+                {
+                    Debug.WriteLine($"GPUPerformanceCounters: counter {pair.Key} failed: {exception.Message}");
+                    deadInstances.Add(pair.Key);
+                }
+            }
+            foreach (var instanceName in deadInstances)
+            {
+                countersByInstance[instanceName].Close();
+                countersByInstance.Remove(instanceName);
+            }
+            return values;
         }
 
         internal void Close()
         {
-            foreach (var counter in Counters) counter.Close();
+            foreach (var counter in countersByInstance.Values) counter.Close();
+            countersByInstance.Clear();
         }
     }
 
     internal class GPURepository
     {
         private const int GPU_INFO_LIST_LIMIT_SIZE = 5;
+        private const int REFRESH_INTERVAL_TICKS = 30;
 
         private readonly GPUPerformanceCounters? counters;
         private readonly List<GPUInfo> gpuInfoList = [];
+        private int ticksSinceLastRefresh;
 
         internal bool IsAvailable => counters is not null;
 
@@ -104,30 +171,27 @@ namespace RunCat365
         internal void Update()
         {
             if (counters is null) return;
-            try
+
+            ticksSinceLastRefresh += 1;
+            if (REFRESH_INTERVAL_TICKS <= ticksSinceLastRefresh)
             {
-                var values = counters.Counters.Select(counter => counter.NextValue()).ToList();
-                if (values.Count == 0) return;
-
-                var gpuInfo = new GPUInfo
-                {
-                    Average = Math.Min(100, values.Average()),
-                    Maximum = Math.Min(100, values.Max())
-                };
-
-                gpuInfoList.Add(gpuInfo);
-                if (GPU_INFO_LIST_LIMIT_SIZE < gpuInfoList.Count)
-                {
-                    gpuInfoList.RemoveAt(0);
-                }
+                ticksSinceLastRefresh = 0;
+                counters.RefreshInstances();
             }
-            catch (Exception exception) when (
-                exception is InvalidOperationException
-                or System.ComponentModel.Win32Exception
-                or UnauthorizedAccessException)
+
+            var values = counters.ReadValues();
+            if (values.Count == 0) return;
+
+            var gpuInfo = new GPUInfo
             {
-                Debug.WriteLine($"GPURepository.Update failed: {exception.Message}");
-                gpuInfoList.Clear();
+                Average = Math.Min(100, values.Average()),
+                Maximum = Math.Min(100, values.Max())
+            };
+
+            gpuInfoList.Add(gpuInfo);
+            if (GPU_INFO_LIST_LIMIT_SIZE < gpuInfoList.Count)
+            {
+                gpuInfoList.RemoveAt(0);
             }
         }
 

--- a/RunCat365/GPURepository.cs
+++ b/RunCat365/GPURepository.cs
@@ -50,7 +50,7 @@ namespace RunCat365
 
         protected override bool ShouldIncludeInstance(string instanceName)
         {
-            return instanceName.Contains(ENGINE_TYPE_FILTER);
+            return instanceName.Contains(ENGINE_TYPE_FILTER, StringComparison.Ordinal);
         }
 
         internal static GPUPerformanceCounters? TryCreate()

--- a/RunCat365/InstancedPerformanceCounters.cs
+++ b/RunCat365/InstancedPerformanceCounters.cs
@@ -1,0 +1,124 @@
+// Copyright 2025 Takuto Nakamura
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.Diagnostics;
+
+namespace RunCat365
+{
+    internal abstract class InstancedPerformanceCounters
+    {
+        private readonly Dictionary<string, PerformanceCounter> countersByInstance = [];
+
+        protected abstract string CategoryName { get; }
+        protected abstract string CounterName { get; }
+
+        protected virtual bool ShouldIncludeInstance(string instanceName) => true;
+
+        internal int Count => countersByInstance.Count;
+
+        protected bool TryInitialize()
+        {
+            try
+            {
+                _ = new PerformanceCounterCategory(CategoryName);
+            }
+            catch
+            {
+                return false;
+            }
+
+            RefreshInstances();
+            return Count != 0;
+        }
+
+        internal void RefreshInstances()
+        {
+            string[] currentInstanceNames;
+            try
+            {
+                var category = new PerformanceCounterCategory(CategoryName);
+                currentInstanceNames = category.GetInstanceNames()
+                    .Where(ShouldIncludeInstance)
+                    .ToArray();
+            }
+            catch (Exception exception) when (IsExpectedCounterException(exception))
+            {
+                Debug.WriteLine($"{GetType().Name}.RefreshInstances failed: {exception.Message}");
+                return;
+            }
+
+            var currentSet = new HashSet<string>(currentInstanceNames, StringComparer.Ordinal);
+            var staleInstances = countersByInstance.Keys
+                .Where(name => !currentSet.Contains(name))
+                .ToList();
+            foreach (var instanceName in staleInstances)
+            {
+                countersByInstance[instanceName].Close();
+                countersByInstance.Remove(instanceName);
+            }
+
+            foreach (var instanceName in currentInstanceNames)
+            {
+                if (countersByInstance.ContainsKey(instanceName)) continue;
+                try
+                {
+                    var counter = new PerformanceCounter(CategoryName, CounterName, instanceName);
+                    _ = counter.NextValue();
+                    countersByInstance[instanceName] = counter;
+                }
+                catch (Exception exception) when (IsExpectedCounterException(exception))
+                {
+                    Debug.WriteLine($"{GetType().Name}: failed to create counter for {instanceName}: {exception.Message}");
+                }
+            }
+        }
+
+        internal List<float> ReadValues()
+        {
+            var values = new List<float>(countersByInstance.Count);
+            var deadInstances = new List<string>();
+            foreach (var pair in countersByInstance)
+            {
+                try
+                {
+                    values.Add(pair.Value.NextValue());
+                }
+                catch (Exception exception) when (IsExpectedCounterException(exception))
+                {
+                    Debug.WriteLine($"{GetType().Name}: counter {pair.Key} failed: {exception.Message}");
+                    deadInstances.Add(pair.Key);
+                }
+            }
+            foreach (var instanceName in deadInstances)
+            {
+                countersByInstance[instanceName].Close();
+                countersByInstance.Remove(instanceName);
+            }
+            return values;
+        }
+
+        internal void Close()
+        {
+            foreach (var counter in countersByInstance.Values) counter.Close();
+            countersByInstance.Clear();
+        }
+
+        private static bool IsExpectedCounterException(Exception exception)
+        {
+            return exception is InvalidOperationException
+                or System.ComponentModel.Win32Exception
+                or UnauthorizedAccessException;
+        }
+    }
+}

--- a/RunCat365/InstancedPerformanceCounters.cs
+++ b/RunCat365/InstancedPerformanceCounters.cs
@@ -71,15 +71,21 @@ namespace RunCat365
             foreach (var instanceName in currentInstanceNames)
             {
                 if (countersByInstance.ContainsKey(instanceName)) continue;
+                PerformanceCounter? counter = null;
                 try
                 {
-                    var counter = new PerformanceCounter(CategoryName, CounterName, instanceName);
+                    counter = new PerformanceCounter(CategoryName, CounterName, instanceName);
                     _ = counter.NextValue();
                     countersByInstance[instanceName] = counter;
+                    counter = null;
                 }
                 catch (Exception exception) when (IsExpectedCounterException(exception))
                 {
                     Debug.WriteLine($"{GetType().Name}: failed to create counter for {instanceName}: {exception.Message}");
+                }
+                finally
+                {
+                    counter?.Close();
                 }
             }
         }

--- a/RunCat365/TemperatureRepository.cs
+++ b/RunCat365/TemperatureRepository.cs
@@ -63,40 +63,105 @@ namespace RunCat365
         private const string CATEGORY_NAME = "Thermal Zone Information";
         private const string COUNTER_NAME = "Temperature";
 
-        internal IReadOnlyList<PerformanceCounter> Counters { get; }
+        private readonly Dictionary<string, PerformanceCounter> countersByInstance = [];
 
-        private TemperaturePerformanceCounters(List<PerformanceCounter> counters)
-        {
-            Counters = counters;
-        }
+        private TemperaturePerformanceCounters() { }
+
+        internal int Count => countersByInstance.Count;
 
         internal static TemperaturePerformanceCounters? TryCreate()
         {
-            var counters = new List<PerformanceCounter>();
             try
             {
-                var category = new PerformanceCounterCategory(CATEGORY_NAME);
-                var instanceNames = category.GetInstanceNames();
-                if (instanceNames.Length == 0) return null;
-
-                foreach (var instance in instanceNames)
-                {
-                    var counter = new PerformanceCounter(CATEGORY_NAME, COUNTER_NAME, instance);
-                    counters.Add(counter);
-                    _ = counter.NextValue();
-                }
-                return new TemperaturePerformanceCounters(counters);
+                _ = new PerformanceCounterCategory(CATEGORY_NAME);
             }
             catch
             {
-                foreach (var counter in counters) counter.Close();
                 return null;
             }
+
+            var instance = new TemperaturePerformanceCounters();
+            instance.RefreshInstances();
+            return instance.Count == 0 ? null : instance;
+        }
+
+        internal void RefreshInstances()
+        {
+            string[] currentInstanceNames;
+            try
+            {
+                var category = new PerformanceCounterCategory(CATEGORY_NAME);
+                currentInstanceNames = category.GetInstanceNames();
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or System.ComponentModel.Win32Exception
+                or UnauthorizedAccessException)
+            {
+                Debug.WriteLine($"TemperaturePerformanceCounters.RefreshInstances failed: {exception.Message}");
+                return;
+            }
+
+            var currentSet = new HashSet<string>(currentInstanceNames, StringComparer.Ordinal);
+            var staleInstances = countersByInstance.Keys
+                .Where(name => !currentSet.Contains(name))
+                .ToList();
+            foreach (var instanceName in staleInstances)
+            {
+                countersByInstance[instanceName].Close();
+                countersByInstance.Remove(instanceName);
+            }
+
+            foreach (var instanceName in currentInstanceNames)
+            {
+                if (countersByInstance.ContainsKey(instanceName)) continue;
+                try
+                {
+                    var counter = new PerformanceCounter(CATEGORY_NAME, COUNTER_NAME, instanceName);
+                    _ = counter.NextValue();
+                    countersByInstance[instanceName] = counter;
+                }
+                catch (Exception exception) when (
+                    exception is InvalidOperationException
+                    or System.ComponentModel.Win32Exception
+                    or UnauthorizedAccessException)
+                {
+                    Debug.WriteLine($"TemperaturePerformanceCounters: failed to create counter for {instanceName}: {exception.Message}");
+                }
+            }
+        }
+
+        internal List<float> ReadValues()
+        {
+            var values = new List<float>(countersByInstance.Count);
+            var deadInstances = new List<string>();
+            foreach (var pair in countersByInstance)
+            {
+                try
+                {
+                    values.Add(pair.Value.NextValue());
+                }
+                catch (Exception exception) when (
+                    exception is InvalidOperationException
+                    or System.ComponentModel.Win32Exception
+                    or UnauthorizedAccessException)
+                {
+                    Debug.WriteLine($"TemperaturePerformanceCounters: counter {pair.Key} failed: {exception.Message}");
+                    deadInstances.Add(pair.Key);
+                }
+            }
+            foreach (var instanceName in deadInstances)
+            {
+                countersByInstance[instanceName].Close();
+                countersByInstance.Remove(instanceName);
+            }
+            return values;
         }
 
         internal void Close()
         {
-            foreach (var counter in Counters) counter.Close();
+            foreach (var counter in countersByInstance.Values) counter.Close();
+            countersByInstance.Clear();
         }
     }
 
@@ -105,9 +170,11 @@ namespace RunCat365
         private const float KELVIN_TO_CELSIUS_OFFSET = 273.15f;
         private const float MIN_VALID_TEMPERATURE_CELSIUS = -50.0f;
         private const float MAX_VALID_TEMPERATURE_CELSIUS = 150.0f;
+        private const int REFRESH_INTERVAL_TICKS = 30;
 
         private readonly TemperaturePerformanceCounters? counters;
         private TemperatureInfo? temperatureInfo;
+        private int ticksSinceLastRefresh;
 
         internal bool IsAvailable => counters is not null;
 
@@ -119,34 +186,31 @@ namespace RunCat365
         internal void Update()
         {
             if (counters is null) return;
-            try
-            {
-                var temperaturesCelsius = new List<float>();
-                foreach (var counter in counters.Counters)
-                {
-                    var temperatureKelvin = counter.NextValue();
-                    if (temperatureKelvin <= 0) continue;
-                    var temperatureCelsius = temperatureKelvin - KELVIN_TO_CELSIUS_OFFSET;
-                    if (temperatureCelsius is < MIN_VALID_TEMPERATURE_CELSIUS or > MAX_VALID_TEMPERATURE_CELSIUS) continue;
-                    temperaturesCelsius.Add(temperatureCelsius);
-                }
 
-                temperatureInfo = temperaturesCelsius.Count == 0
-                    ? null
-                    : new TemperatureInfo
-                    {
-                        AverageCelsius = temperaturesCelsius.Average(),
-                        MaximumCelsius = temperaturesCelsius.Max()
-                    };
-            }
-            catch (Exception exception) when (
-                exception is InvalidOperationException
-                or System.ComponentModel.Win32Exception
-                or UnauthorizedAccessException)
+            ticksSinceLastRefresh += 1;
+            if (REFRESH_INTERVAL_TICKS <= ticksSinceLastRefresh)
             {
-                Debug.WriteLine($"TemperatureRepository.Update failed: {exception.Message}");
-                temperatureInfo = null;
+                ticksSinceLastRefresh = 0;
+                counters.RefreshInstances();
             }
+
+            var rawValues = counters.ReadValues();
+            var temperaturesCelsius = new List<float>(rawValues.Count);
+            foreach (var temperatureKelvin in rawValues)
+            {
+                if (temperatureKelvin <= 0) continue;
+                var temperatureCelsius = temperatureKelvin - KELVIN_TO_CELSIUS_OFFSET;
+                if (temperatureCelsius is < MIN_VALID_TEMPERATURE_CELSIUS or > MAX_VALID_TEMPERATURE_CELSIUS) continue;
+                temperaturesCelsius.Add(temperatureCelsius);
+            }
+
+            temperatureInfo = temperaturesCelsius.Count == 0
+                ? null
+                : new TemperatureInfo
+                {
+                    AverageCelsius = temperaturesCelsius.Average(),
+                    MaximumCelsius = temperaturesCelsius.Max()
+                };
         }
 
         internal TemperatureInfo? Get()

--- a/RunCat365/TemperatureRepository.cs
+++ b/RunCat365/TemperatureRepository.cs
@@ -13,7 +13,6 @@
 //    limitations under the License.
 
 using RunCat365.Properties;
-using System.Diagnostics;
 using System.Globalization;
 
 namespace RunCat365
@@ -58,110 +57,15 @@ namespace RunCat365
         }
     }
 
-    internal class TemperaturePerformanceCounters
+    internal sealed class TemperaturePerformanceCounters : InstancedPerformanceCounters
     {
-        private const string CATEGORY_NAME = "Thermal Zone Information";
-        private const string COUNTER_NAME = "Temperature";
-
-        private readonly Dictionary<string, PerformanceCounter> countersByInstance = [];
-
-        private TemperaturePerformanceCounters() { }
-
-        internal int Count => countersByInstance.Count;
+        protected override string CategoryName => "Thermal Zone Information";
+        protected override string CounterName => "Temperature";
 
         internal static TemperaturePerformanceCounters? TryCreate()
         {
-            try
-            {
-                _ = new PerformanceCounterCategory(CATEGORY_NAME);
-            }
-            catch
-            {
-                return null;
-            }
-
             var instance = new TemperaturePerformanceCounters();
-            instance.RefreshInstances();
-            return instance.Count == 0 ? null : instance;
-        }
-
-        internal void RefreshInstances()
-        {
-            string[] currentInstanceNames;
-            try
-            {
-                var category = new PerformanceCounterCategory(CATEGORY_NAME);
-                currentInstanceNames = category.GetInstanceNames();
-            }
-            catch (Exception exception) when (
-                exception is InvalidOperationException
-                or System.ComponentModel.Win32Exception
-                or UnauthorizedAccessException)
-            {
-                Debug.WriteLine($"TemperaturePerformanceCounters.RefreshInstances failed: {exception.Message}");
-                return;
-            }
-
-            var currentSet = new HashSet<string>(currentInstanceNames, StringComparer.Ordinal);
-            var staleInstances = countersByInstance.Keys
-                .Where(name => !currentSet.Contains(name))
-                .ToList();
-            foreach (var instanceName in staleInstances)
-            {
-                countersByInstance[instanceName].Close();
-                countersByInstance.Remove(instanceName);
-            }
-
-            foreach (var instanceName in currentInstanceNames)
-            {
-                if (countersByInstance.ContainsKey(instanceName)) continue;
-                try
-                {
-                    var counter = new PerformanceCounter(CATEGORY_NAME, COUNTER_NAME, instanceName);
-                    _ = counter.NextValue();
-                    countersByInstance[instanceName] = counter;
-                }
-                catch (Exception exception) when (
-                    exception is InvalidOperationException
-                    or System.ComponentModel.Win32Exception
-                    or UnauthorizedAccessException)
-                {
-                    Debug.WriteLine($"TemperaturePerformanceCounters: failed to create counter for {instanceName}: {exception.Message}");
-                }
-            }
-        }
-
-        internal List<float> ReadValues()
-        {
-            var values = new List<float>(countersByInstance.Count);
-            var deadInstances = new List<string>();
-            foreach (var pair in countersByInstance)
-            {
-                try
-                {
-                    values.Add(pair.Value.NextValue());
-                }
-                catch (Exception exception) when (
-                    exception is InvalidOperationException
-                    or System.ComponentModel.Win32Exception
-                    or UnauthorizedAccessException)
-                {
-                    Debug.WriteLine($"TemperaturePerformanceCounters: counter {pair.Key} failed: {exception.Message}");
-                    deadInstances.Add(pair.Key);
-                }
-            }
-            foreach (var instanceName in deadInstances)
-            {
-                countersByInstance[instanceName].Close();
-                countersByInstance.Remove(instanceName);
-            }
-            return values;
-        }
-
-        internal void Close()
-        {
-            foreach (var counter in countersByInstance.Values) counter.Close();
-            countersByInstance.Clear();
+            return instance.TryInitialize() ? instance : null;
         }
     }
 


### PR DESCRIPTION
## Context of Contribution

- [x] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [ ] Others

## Summary of the Proposal

Improves CPU/GPU/temperature monitoring to better match Task Manager and to survive devices being added or removed at runtime. The CPU repository selects its performance counter based on the OS build (using the "Processor Information" category with "% Processor Utility" / "% Processor Time" to match Task Manager's metric change in 24H2) and derives idle time from user/kernel instead of a dedicated counter. The GPU and temperature repositories periodically refresh their counter instances and drop dead ones instead of failing permanently; their now-identical instance-management logic is extracted into a shared `InstancedPerformanceCounters` base class.

## Reason for the new feature

N/A

## Checklist

- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the Microsoft Store.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.