### PR TITLE
Treat thermal zones with never-changing readings as unavailable

### DIFF
--- a/RunCat365/TemperatureRepository.cs
+++ b/RunCat365/TemperatureRepository.cs
@@ -75,10 +75,14 @@ namespace RunCat365
         private const float MIN_VALID_TEMPERATURE_CELSIUS = -50.0f;
         private const float MAX_VALID_TEMPERATURE_CELSIUS = 150.0f;
         private const int REFRESH_INTERVAL_TICKS = 30;
+        private const int STALE_READ_THRESHOLD = 24;
 
         private readonly TemperaturePerformanceCounters? counters;
+        private readonly List<float> baselineRawValues = [];
         private TemperatureInfo? temperatureInfo;
         private int ticksSinceLastRefresh;
+        private int identicalReadCount;
+        private bool hasEverVaried;
 
         internal bool IsAvailable => counters is not null;
 
@@ -99,6 +103,8 @@ namespace RunCat365
             }
 
             var rawValues = counters.ReadValues();
+            TrackValueVariation(rawValues);
+
             var temperaturesCelsius = new List<float>(rawValues.Count);
             foreach (var temperatureKelvin in rawValues)
             {
@@ -108,13 +114,50 @@ namespace RunCat365
                 temperaturesCelsius.Add(temperatureCelsius);
             }
 
-            temperatureInfo = temperaturesCelsius.Count == 0
+            temperatureInfo = temperaturesCelsius.Count == 0 || IsLikelyPlaceholder()
                 ? null
                 : new TemperatureInfo
                 {
                     AverageCelsius = temperaturesCelsius.Average(),
                     MaximumCelsius = temperaturesCelsius.Max()
                 };
+        }
+
+        // Some firmware exposes an ACPI thermal zone that is not wired to a real
+        // sensor and always reports the same fixed value (e.g. 301 K). Track whether
+        // the readings have ever changed so such zones can be treated as unavailable
+        // instead of showing a misleading constant temperature.
+        private void TrackValueVariation(List<float> rawValues)
+        {
+            if (hasEverVaried || rawValues.Count == 0) return;
+
+            var sortedValues = new List<float>(rawValues);
+            sortedValues.Sort();
+
+            if (baselineRawValues.Count != sortedValues.Count)
+            {
+                baselineRawValues.Clear();
+                baselineRawValues.AddRange(sortedValues);
+                identicalReadCount = 1;
+                return;
+            }
+
+            for (var i = 0; i < sortedValues.Count; i++)
+            {
+                if (baselineRawValues[i] != sortedValues[i])
+                {
+                    hasEverVaried = true;
+                    baselineRawValues.Clear();
+                    return;
+                }
+            }
+
+            identicalReadCount += 1;
+        }
+
+        private bool IsLikelyPlaceholder()
+        {
+            return !hasEverVaried && STALE_READ_THRESHOLD <= identicalReadCount;
         }
 
         internal TemperatureInfo? Get()

--- a/RunCat365/TemperatureRepository.cs
+++ b/RunCat365/TemperatureRepository.cs
@@ -69,6 +69,18 @@ namespace RunCat365
         }
     }
 
+    internal sealed class TemperatureHighPrecisionPerformanceCounters : InstancedPerformanceCounters
+    {
+        protected override string CategoryName => "Thermal Zone Information";
+        protected override string CounterName => "High Precision Temperature";
+
+        internal static TemperatureHighPrecisionPerformanceCounters? TryCreate()
+        {
+            var instance = new TemperatureHighPrecisionPerformanceCounters();
+            return instance.TryInitialize() ? instance : null;
+        }
+    }
+
     internal class TemperatureRepository
     {
         private const float KELVIN_TO_CELSIUS_OFFSET = 273.15f;
@@ -78,6 +90,7 @@ namespace RunCat365
         private const int STALE_READ_THRESHOLD = 24;
 
         private readonly TemperaturePerformanceCounters? counters;
+        private readonly TemperatureHighPrecisionPerformanceCounters? highPrecisionCounters;
         private readonly List<float> baselineRawValues = [];
         private TemperatureInfo? temperatureInfo;
         private int ticksSinceLastRefresh;
@@ -89,6 +102,7 @@ namespace RunCat365
         internal TemperatureRepository()
         {
             counters = TemperaturePerformanceCounters.TryCreate();
+            highPrecisionCounters = TemperatureHighPrecisionPerformanceCounters.TryCreate();
         }
 
         internal void Update()
@@ -100,10 +114,12 @@ namespace RunCat365
             {
                 ticksSinceLastRefresh = 0;
                 counters.RefreshInstances();
+                highPrecisionCounters?.RefreshInstances();
             }
 
             var rawValues = counters.ReadValues();
-            TrackValueVariation(rawValues);
+            var variationValues = highPrecisionCounters is null ? rawValues : highPrecisionCounters.ReadValues();
+            TrackValueVariation(variationValues);
 
             var temperaturesCelsius = new List<float>(rawValues.Count);
             foreach (var temperatureKelvin in rawValues)
@@ -126,7 +142,12 @@ namespace RunCat365
         // Some firmware exposes an ACPI thermal zone that is not wired to a real
         // sensor and always reports the same fixed value (e.g. 301 K). Track whether
         // the readings have ever changed so such zones can be treated as unavailable
-        // instead of showing a misleading constant temperature.
+        // instead of showing a misleading constant temperature. Variation is tracked
+        // on the "High Precision Temperature" counter (0.1 K granularity) when it is
+        // available, because a live sensor jitters at that resolution even when the
+        // whole-Kelvin "Temperature" counter stays flat on an idle machine; the
+        // tracking source is fixed at construction so values are never compared
+        // across the two counters' different scales.
         private void TrackValueVariation(List<float> rawValues)
         {
             if (hasEverVaried || rawValues.Count == 0) return;
@@ -168,6 +189,7 @@ namespace RunCat365
         internal void Close()
         {
             counters?.Close();
+            highPrecisionCounters?.Close();
         }
     }
 }


### PR DESCRIPTION
## Context of Contribution

- [x] Bug Fix
- [ ] Refactoring
- [ ] New Feature
- [ ] Others

## Summary of the Proposal

On some machines the ACPI thermal zone exposed through the "Thermal Zone Information" performance counter is not wired to a real sensor and always reports a fixed placeholder value. On a GIGABYTE AERO 15 KC (Windows 11), the only zone `\_TZ.TZ00` constantly reports 301 K (27.85 °C) even under sustained full CPU load — while the real CPU package temperature at the same moment was 88 °C (verified with LibreHardwareMonitor). RunCat 365 therefore permanently shows a misleading ~28 °C in the notify icon tooltip and the system info menu.

This PR tracks whether the thermal zone readings have ever changed since startup. After 24 identical consecutive reads (about 2 minutes at the current fetch cadence of one temperature update per 5 seconds), the zone is treated as a placeholder and the temperature entry is hidden — the same behavior as on machines that expose no thermal zone at all. Detection is self-correcting: readings are still taken on every update, and if any value ever changes, the temperature is shown again permanently.

To keep false positives out, variation is tracked on the "High Precision Temperature" counter of the same category (0.1 K granularity) when it is available: a live sensor jitters at that resolution even when the whole-Kelvin "Temperature" counter legitimately stays flat on an idle machine. When the high-precision counter is unavailable the tracking falls back to the Temperature counter values; the tracking source is fixed at construction so readings are never compared across the two counters' different scales. (On the affected machine the placeholder zone reports both counters bit-identical forever: Temperature = 301, High Precision = 3010.)

Residual trade-off: on firmware whose high-precision counter is just a ×10 copy of the whole-Kelvin value, a genuinely constant sensor could still be hidden after the 2-minute window until its reading first drifts. The failure mode is temporary hiding of a stale-looking value rather than showing wrong data, and it heals permanently on the first observed change.

Verified on the affected machine: with this change the placeholder zone is hidden after 2 minutes; the change builds with 0 errors and no new warnings, adds no dependencies, and does not alter behavior on machines whose thermal zones report real (varying) values.

## Reason for the new feature

N/A (bug fix).

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and agree to follow it.
- [x] This PR does not contain commits of multiple contexts.
- [x] Code follows proper indentation and naming conventions.
- [x] Implemented using only APIs that can be submitted to the Microsoft Store. (Uses the already-referenced performance counter API only; no new dependencies.)
- [x] Works correctly in both dark theme and light theme. (No UI change.)
- [x] Works correctly on any device. (Pure logic change on the existing counter path; machines with varying thermal zone readings are unaffected.)
